### PR TITLE
provides compatibility with >=numpy-1.9.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ import glob
 import shutil
 from distutils.core import setup
 from distutils.core import Extension, Command
-import  as np
+import numpy as np
 from distutils.command.sdist import sdist
 
 ################################################################################


### PR DESCRIPTION
numpy.get_include is the public method to identify the include directory
