### PR TITLE
Fix edf constructor

### DIFF
--- a/fabio/edfimage.py
+++ b/fabio/edfimage.py
@@ -474,11 +474,7 @@ class EdfImage(FabioImage):
             elif dim == 2:
                 stored_data = data
             elif dim >= 3:
-                logger.warning("Data dimension too big. Only the last 2-dimensions will be used")
-                selection = [0] * dim
-                selection[-1] = slice(None)
-                selection[-2] = slice(None)
-                stored_data = data[selection]
+                raise Exception("Data dimension too big. Only 1d or 2d arrays are supported.")
 
         FabioImage.__init__(self, stored_data, header)
 

--- a/fabio/edfimage.py
+++ b/fabio/edfimage.py
@@ -453,24 +453,34 @@ class EdfImage(FabioImage):
     def __init__(self, data=None, header=None, frames=None):
         self.currentframe = 0
         self.filesize = None
-        try:
-            dim = len(data.shape)
-        except Exception as error:  # IGNORE:W0703
-            logger.debug("Data don't look like a numpy array (%s), resetting all!!" % error)
-            data = None
-            dim = 0
-            FabioImage.__init__(self, data, header)
-        if dim == 2:
-            FabioImage.__init__(self, data, header)
-        elif dim == 1:
-            data.shape = (1, len(data))
-            FabioImage.__init__(self, data, header)
-        elif dim == 3:
-            FabioImage.__init__(self, data[0, :, :], header)
-        elif dim == 4:
-            FabioImage.__init__(self, data[0, 0, :, :], header)
-        elif dim == 5:
-            FabioImage.__init__(self, data[0, 0, 0, :, :], header)
+
+        if data is None:
+            # In case of creation of an empty instance
+            stored_data = None
+        else:
+            try:
+                dim = len(data.shape)
+            except Exception as error:  # IGNORE:W0703
+                logger.debug("Data don't look like a numpy array (%s), resetting all!!" % error)
+                dim = 0
+
+            if dim == 0:
+                raise Exception("Data with empty shape is unsupported")
+            elif dim == 1:
+                logger.warning("Data in 1d dimension will be stored as a 2d dimension array")
+                # make sure we do not change the shape of the input data
+                stored_data = numpy.array(data, copy=False)
+                stored_data.shape = (1, len(data))
+            elif dim == 2:
+                stored_data = data
+            elif dim >= 3:
+                logger.warning("Data dimension too big. Only the last 2-dimensions will be used")
+                selection = [0] * dim
+                selection[-1] = slice(None)
+                selection[-2] = slice(None)
+                stored_data = data[selection]
+
+        FabioImage.__init__(self, stored_data, header)
 
         if frames is None:
             frame = Frame(data=self.data, header=self.header,

--- a/fabio/fabioimage.py
+++ b/fabio/fabioimage.py
@@ -46,7 +46,7 @@ __authors__ = ["Henning O. Sorensen", "Erik Knudsen", "Jon Wright", "Jérôme Ki
 __contact__ = "jerome.kieffer@esrf.fr"
 __license__ = "MIT"
 __copyright__ = "ESRF"
-__date__ = "12/12/2016"
+__date__ = "30/01/2017"
 
 
 import os
@@ -94,7 +94,7 @@ class FabioMeta(type):
 
 class FabioImage(with_metaclass(FabioMeta, object)):
     """A common object for images in fable
-    
+
     Contains a numpy array (.data) and dict of meta data (.header)
     """
 
@@ -129,16 +129,16 @@ class FabioImage(with_metaclass(FabioMeta, object)):
 
     def __init__(self, data=None, header=None):
         """Set up initial values
-        
+
         @param data: numpy array of values
-        @param header: dict or ordereddict with metadata 
+        @param header: dict or ordereddict with metadata
         """
         self._classname = None
         self._dim1 = self._dim2 = self._bpp = 0
         self._bytecode = None
         self._file = None
         if type(data) in fabioutils.StringTypes:
-            raise Exception("fabioimage.__init__ bad argument - " + \
+            raise Exception("fabioimage.__init__ bad argument - " +
                             "data should be numpy array")
         self.data = self.check_data(data)
         self.pilimage = None
@@ -303,14 +303,13 @@ class FabioImage(with_metaclass(FabioMeta, object)):
         # mode map
         size = self.data.shape[:2][::-1]
         typmap = {
-                  'float32': "F",
-                  'int32': "F;32NS",
-                  'uint32': "F;32N",
-                  'int16': "F;16NS",
-                  'uint16': "F;16N",
-                  'int8': "F;8S",
-                  'uint8': "F;8"
-                 }
+            'float32': "F",
+            'int32': "F;32NS",
+            'uint32': "F;32N",
+            'int16': "F;16NS",
+            'uint16': "F;16N",
+            'int8': "F;8S",
+            'uint8': "F;8"}
         if self.data.dtype.name in typmap:
             mode2 = typmap[self.data.dtype.name]
             mode1 = mode2[0]
@@ -376,7 +375,7 @@ class FabioImage(with_metaclass(FabioMeta, object)):
         if len(coords) == 4:
             sli = self.make_slice(coords)
         elif len(coords) == 2 and isinstance(coords[0], slice) and \
-                        isinstance(coords[1], slice):
+                isinstance(coords[1], slice):
             sli = coords
 
         if sli == self.slice and self.area_sum is not None:
@@ -517,7 +516,7 @@ class FabioImage(with_metaclass(FabioMeta, object)):
         if len(coords) == 4:
             self.slice = self.make_slice(coords)
         elif len(coords) == 2 and isinstance(coords[0], slice) and \
-             isinstance(coords[1], slice):
+                isinstance(coords[1], slice):
             self.slice = coords
         else:
             logger.warning('readROI: Unable to understand Region Of Interest: got %s', coords)


### PR DESCRIPTION
This patch add robustness on EdfImage constructor

It contains
- A refactoring to be sure the super constructor is always called
- It take care of the case where dim==0 and raise an exception
- The last patch avoid using array bigger than 2d (before that, the input data was not fully used). We can remove it if you think it is safer for compatibility.