### PR TITLE
Fix build on Windows for python3.6-64 bits

### DIFF
--- a/fabio/ext/include/ccp4_pack.h
+++ b/fabio/ext/include/ccp4_pack.h
@@ -19,7 +19,7 @@
 #ifndef CPP4_PACK_H
 #define CPP4_PACK_H
 
-#ifndef _MSC_VER
+#if !defined(_MSC_VER) || (_MSC_VER >= 1900)
 #include <stdint.h>
 #else
 #include "msvc\\stdint.h"


### PR DESCRIPTION
Use default stdint.h with MSVC++ 14.0: closes #104