### PR TITLE
Fix OXD for pilatus300k

### DIFF
--- a/fabio/OXDimage.py
+++ b/fabio/OXDimage.py
@@ -48,7 +48,7 @@ from __future__ import with_statement, print_function
 __contact__ = "Jerome.Kieffer@esrf.fr"
 __license__ = "MIT"
 __copyright__ = "Jérôme Kieffer"
-__date__ = "26/10/2016"
+__date__ = "09/02/2017"
 
 import time
 import logging
@@ -69,7 +69,8 @@ DETECTOR_TYPES = {0: 'Sapphire/KM4CCD (1x1: 0.06mm, 2x2: 0.12mm)',
                   1: 'Sapphire2-Kodak (1x1: 0.06mm, 2x2: 0.12mm)',
                   2: 'Sapphire3-Kodak (1x1: 0.03mm, 2x2: 0.06mm, 4x4: 0.12mm)',
                   3: 'Onyx-Kodak (1x1: 0.06mm, 2x2: 0.12mm, 4x4: 0.24mm)',
-                  4: 'Unknown Oxford diffraction detector'}
+                  4: 'Unknown Oxford diffraction detector',
+                  7: 'Pilatus 300K-Dectris'}
 
 DEFAULT_HEADERS = {'Header Version': 'OD SAPPHIRE  3.0',
                    'Compression': "TY1",
@@ -210,9 +211,9 @@ class OxdImage(FabioImage):
         self.header['Beam center x'] = struct.unpack("<d", block[664:672])[0]
         self.header['Beam center y'] = struct.unpack("<d", block[672:680])[0]
         # Angle (alpha) between kappa rotation axis and e3 (ideally 50 deg)
-        self.header['Alpha angle in deg'] = struct.unpack("<d", block[672:680])[0]
+        self.header['Alpha angle in deg'] = struct.unpack("<d", block[680:688])[0]
         # Angle (beta) between phi rotation axis and e3 (ideally 0 deg)
-        self.header['Beta angle in deg'] = struct.unpack("<d", block[672:680])[0]
+        self.header['Beta angle in deg'] = struct.unpack("<d", block[688:696])[0]
 
         # Detector distance
         self.header['Distance in mm'] = struct.unpack("<d", block[712:720])[0]

--- a/fabio/OXDimage.py
+++ b/fabio/OXDimage.py
@@ -426,9 +426,9 @@ class OxdImage(FabioImage):
         KM.setData('Beam center x', 664, numpy.float64)
         KM.setData('Beam center y', 672, numpy.float64)
         # Angle (alpha) between kappa rotation axis and e3 (ideally 50 deg)
-        KM.setData('Alpha angle in deg', 672, numpy.float64)
+        KM.setData('Alpha angle in deg', 680, numpy.float64)
         # Angle (beta) between phi rotation axis and e3 (ideally 0 deg)
-        KM.setData('Beta angle in deg', 672, numpy.float64)
+        KM.setData('Beta angle in deg', 688, numpy.float64)
 
         # Detector distance
         KM.setData('Distance in mm', 712, numpy.float64)

--- a/fabio/OXDimage.py
+++ b/fabio/OXDimage.py
@@ -120,12 +120,14 @@ class OxdImage(FabioImage):
         self.header['NSUPPLEMENT'] = int(block[12:19])
         block = infile.readline()
         self.header['Time'] = to_str(block[5:29])
-        self.header["ASCII Section size in Byte"] = self.header['Header Size In Bytes']\
-                                                   - self.header['General Section size in Byte']\
-                                                   - self.header['Special Section size in Byte'] \
-                                                   - self.header['KM4 Section size in Byte']\
-                                                   - self.header['Statistic Section in Byte']\
-                                                   - self.header['History Section in Byte']
+
+        ascii_section_size = self.header['Header Size In Bytes'] - (
+            self.header['General Section size in Byte'] +
+            self.header['Special Section size in Byte'] +
+            self.header['KM4 Section size in Byte'] +
+            self.header['Statistic Section in Byte'] +
+            self.header['History Section in Byte'])
+        self.header["ASCII Section size in Byte"] = ascii_section_size
 
         # Skip to general section (NG) 512 byes long <<<<<<"
         infile.seek(self.header["ASCII Section size in Byte"])
@@ -288,7 +290,7 @@ class OxdImage(FabioImage):
                 # Always assume little-endian on the disk
                 if not numpy.little_endian:
                     raw_data.byteswap(True)
-#         infile.close()
+        # infile.close()
 
         logger.debug('OVER_SHORT2: %s', raw_data.dtype)
         logger.debug("%s" % (raw_data < 0).sum())
@@ -448,7 +450,7 @@ class OxdImage(FabioImage):
         if self.header.get("Compression") != "TY1":
             logger.warning("Enforce TY1 compression")
             self.header["Compression"] = "TY1"
-    
+
         datablock8, datablock16, datablock32 = compTY1(self.data)
         self.header["OI"] = len(datablock16) / 2
         self.header["OL"] = len(datablock32) / 4
@@ -491,7 +493,7 @@ class OxdImage(FabioImage):
             value = raw[pos_inp]
             if value < 254:
                 # this is the normal case
-#               # 1 bytes encode one pixel
+                # 1 bytes encode one pixel
                 current = last + value - 127
                 pos_inp += 1
             elif value == 254:

--- a/fabio/OXDimage.py
+++ b/fabio/OXDimage.py
@@ -121,12 +121,19 @@ class OxdImage(FabioImage):
         block = infile.readline()
         self.header['Time'] = to_str(block[5:29])
 
-        ascii_section_size = self.header['Header Size In Bytes'] - (
-            self.header['General Section size in Byte'] +
-            self.header['Special Section size in Byte'] +
-            self.header['KM4 Section size in Byte'] +
-            self.header['Statistic Section in Byte'] +
-            self.header['History Section in Byte'])
+        header_version = float(self.header['Header Version'].split()[2])
+        if header_version < 4.0:
+            # for all our test files with header version 3.0
+            # ascii_section_size == 256
+            # but that's a legacy code
+            ascii_section_size = self.header['Header Size In Bytes'] - (
+                self.header['General Section size in Byte'] +
+                self.header['Special Section size in Byte'] +
+                self.header['KM4 Section size in Byte'] +
+                self.header['Statistic Section in Byte'] +
+                self.header['History Section in Byte'])
+        else:
+            ascii_section_size = DEFAULT_HEADERS["ASCII Section size in Byte"]
         self.header["ASCII Section size in Byte"] = ascii_section_size
 
         # Skip to general section (NG) 512 byes long <<<<<<"

--- a/fabio/test/testOXDimage.py
+++ b/fabio/test/testOXDimage.py
@@ -54,9 +54,10 @@ from fabio.OXDimage import OXDimage
 
 # filename dim1 dim2 min max mean stddev values are from OD Sapphire 3.0
 TESTIMAGES = [
-    ("b191_1_9_1.img", 512, 512, -500, 11975, 25.70, 90.2526),
-    ("b191_1_9_1_uncompressed.img", 512, 512, -500, 11975, 25.70, 90.2526),
-    ("100nmfilmonglass_1_1.img", 1024, 1024, -172, 460, 44.20, 63.0245)]
+    ("b191_1_9_1.img", 512, 512, -500, 11975, 25.70, 90.2526, "Sapphire2"),
+    ("b191_1_9_1_uncompressed.img", 512, 512, -500, 11975, 25.70, 90.2526, "Sapphire2"),
+    ("100nmfilmonglass_1_1.img", 1024, 1024, -172, 460, 44.20, 63.0245, "Sapphire3"),
+    ("pilatus300k.rod_img", 487, 619, -2, 173075, 27.315, 538.938, "Pilatus")]
 
 
 class TestOxd(unittest.TestCase):
@@ -77,7 +78,8 @@ class TestOxd(unittest.TestCase):
         for vals in TESTIMAGES:
             name = vals[0]
             dim1, dim2 = vals[1:3]
-            mini, maxi, mean, stddev = vals[3:]
+            mini, maxi, mean, stddev = vals[3:7]
+            detector_type = vals[7]
             obj = OXDimage()
             obj.read(self.fn[name])
 
@@ -88,6 +90,9 @@ class TestOxd(unittest.TestCase):
             self.assertAlmostEqual(maxi, obj.getmax(), 2, "getmax on " + name)
             self.assertAlmostEqual(mean, obj.getmean(), 2, "getmean on " + name)
             self.assertAlmostEqual(stddev, obj.getstddev(), 2, "getstddev on " + name)
+
+            self.assertIn(detector_type, obj.header["Detector type"], "detector type on " + name)
+
     def test_write(self):
         "Test writing with self consistency at the fabio level"
         for vals in TESTIMAGES:

--- a/fabio/test/testOXDimage.py
+++ b/fabio/test/testOXDimage.py
@@ -53,17 +53,18 @@ from fabio.OXDimage import OXDimage
 
 
 # filename dim1 dim2 min max mean stddev values are from OD Sapphire 3.0
-TESTIMAGES = """b191_1_9_1.img  512 512 -500 11975 25.70 90.2526
-                b191_1_9_1_uncompressed.img  512 512 -500 11975 25.70 90.2526
-                100nmfilmonglass_1_1.img 1024 1024 -172 460 44.20 63.0245"""
+TESTIMAGES = [
+    ("b191_1_9_1.img", 512, 512, -500, 11975, 25.70, 90.2526),
+    ("b191_1_9_1_uncompressed.img", 512, 512, -500, 11975, 25.70, 90.2526),
+    ("100nmfilmonglass_1_1.img", 1024, 1024, -172, 460, 44.20, 63.0245)]
 
 
 class TestOxd(unittest.TestCase):
     def setUp(self):
         self.fn = {}
-        for l in TESTIMAGES.split("\n"):
-            i = l.split()[0]
-            self.fn[i] = UtilsTest.getimage(i + ".bz2")[:-4]
+        for vals in TESTIMAGES:
+            name = vals[0]
+            self.fn[name] = UtilsTest.getimage(name + ".bz2")[:-4]
         for i in self.fn:
             assert os.path.exists(self.fn[i])
 
@@ -73,11 +74,10 @@ class TestOxd(unittest.TestCase):
 
     def test_read(self):
         "Test reading of compressed OXD images"
-        for line in TESTIMAGES.split("\n"):
-            vals = line.split()
+        for vals in TESTIMAGES:
             name = vals[0]
-            dim1, dim2 = [int(x) for x in vals[1:3]]
-            mini, maxi, mean, stddev = [float(x) for x in vals[3:]]
+            dim1, dim2 = vals[1:3]
+            mini, maxi, mean, stddev = vals[3:]
             obj = OXDimage()
             obj.read(self.fn[name])
 
@@ -90,8 +90,7 @@ class TestOxd(unittest.TestCase):
 
     def test_write(self):
         "Test writing with self consistency at the fabio level"
-        for line in TESTIMAGES.split("\n"):
-            vals = line.split()
+        for vals in TESTIMAGES:
             name = vals[0]
             obj = OXDimage()
             obj.read(self.fn[name])

--- a/fabio/test/testOXDimage.py
+++ b/fabio/test/testOXDimage.py
@@ -81,13 +81,13 @@ class TestOxd(unittest.TestCase):
             obj = OXDimage()
             obj.read(self.fn[name])
 
-            self.assertAlmostEqual(mini, obj.getmin(), 2, "getmin")
-            self.assertAlmostEqual(maxi, obj.getmax(), 2, "getmax")
-            self.assertAlmostEqual(mean, obj.getmean(), 2, "getmean")
-            self.assertAlmostEqual(stddev, obj.getstddev(), 2, "getstddev")
             self.assertEqual(dim1, obj.dim1, "dim1")
             self.assertEqual(dim2, obj.dim2, "dim2")
 
+            self.assertAlmostEqual(mini, obj.getmin(), 2, "getmin on " + name)
+            self.assertAlmostEqual(maxi, obj.getmax(), 2, "getmax on " + name)
+            self.assertAlmostEqual(mean, obj.getmean(), 2, "getmean on " + name)
+            self.assertAlmostEqual(stddev, obj.getstddev(), 2, "getstddev on " + name)
     def test_write(self):
         "Test writing with self consistency at the fabio level"
         for vals in TESTIMAGES:
@@ -100,12 +100,12 @@ class TestOxd(unittest.TestCase):
             obj.write(os.path.join(UtilsTest.tempdir, name))
             other = OXDimage()
             other.read(os.path.join(UtilsTest.tempdir, name))
-            self.assertEqual(abs(obj.data - other.data).max(), 0, "data are the same for %s" % name)
+            self.assertEqual(abs(obj.data - other.data).max(), 0, "data are not the same for %s" % name)
             for key in obj.header:
                 if key == "filename":
                     continue
                 self.assertTrue(key in other.header, "Key %s is in header" % key)
-                self.assertEqual(obj.header[key], other.header[key], "value are the same for key %s" % key)
+                self.assertEqual(obj.header[key], other.header[key], "metadata '%s' are not the same for %s" % (key, name))
 
             os.unlink(os.path.join(UtilsTest.tempdir, name))
 


### PR DESCRIPTION
- Ascii header size is now fixed for sapphire 4.0 header (it can be a regression)
- Fix header reading for sapphire 4.0 header (it was also wrong for our testfile)
- Fix read and write of alpha/beta angles
- Add Pilatus300k detector type (detector type 5 and 6 are still missing)
- Add a new test file `pilatus300k.rod_img` provided by @Niolon