### PR TITLE
Fix end of iteration for multiframe single EDF file

### DIFF
--- a/fabio/edfimage.py
+++ b/fabio/edfimage.py
@@ -660,9 +660,8 @@ class EdfImage(FabioImage):
             newImage.filename = self.filename
             newImage._file = self._file
         else:
-            txt = "Cannot access frame: %s/%s" % (num, self.nframes)
-            logger.error(txt)
-            raise ValueError("EdfImage.getframe:" + txt)
+            raise IOError("EdfImage.getframe: Cannot access frame: %s/%s" %
+                          (num, self.nframes))
         return newImage
 
     def previous(self):
@@ -676,7 +675,10 @@ class EdfImage(FabioImage):
         return newImage
 
     def next(self):
-        """ returns the next file in the series as a FabioImage """
+        """Returns the next file in the series as a fabioimage
+
+        @raise IOError: When there is no next file or image in the series.
+        """
         newImage = None
         if self.nframes == 1:
             newImage = FabioImage.next(self)

--- a/fabio/fabioimage.py
+++ b/fabio/fabioimage.py
@@ -284,7 +284,10 @@ class FabioImage(with_metaclass(FabioMeta, object)):
         return openimage(fabioutils.previous_filename(self.filename))
 
     def next(self):
-        """ returns the next file in the series as a fabioimage """
+        """Returns the next file in the series as a fabioimage
+
+        @raise IOError: When there is no next file in the series.
+        """
         from .openimage import openimage
         return openimage(
             fabioutils.next_filename(self.filename))


### PR DESCRIPTION
`edfimage.next` raises `ValueError` when reaching the end of a multiframe EDF that `fabioimage.__iter__` didn't catch.

Still, `edfimage.getframe` will log an error right before raising the `ValueError` exception.

Closes #109