### PR TITLE
Fix Python 3.6 on CI

### DIFF
--- a/ci/appveyor.yml
+++ b/ci/appveyor.yml
@@ -49,6 +49,22 @@ environment:
       PYTHON_VERSION: "3.4.3"
       PYTHON_ARCH: "64"
 
+    - PYTHON: "C:\\Python35"
+      PYTHON_VERSION: "3.5.x"
+      PYTHON_ARCH: "32"
+
+    - PYTHON: "C:\\Python35-x64"
+      PYTHON_VERSION: "3.5.x"
+      PYTHON_ARCH: "64"
+
+    - PYTHON: "C:\\Python36"
+      PYTHON_VERSION: "3.6.x"
+      PYTHON_ARCH: "32"
+
+    - PYTHON: "C:\\Python36-x64"
+      PYTHON_VERSION: "3.6.x"
+      PYTHON_ARCH: "64"
+
 
 install:
   # Install Python (from the official .msi of http://python.org) and pip when

--- a/fabio/ext/include/msvc/stdint.h
+++ b/fabio/ext/include/msvc/stdint.h
@@ -90,26 +90,6 @@ typedef __int64              int64_t;
 typedef unsigned __int64     uint64_t;
 
 
-// 7.18.1.2 Minimum-width integer types
-typedef int8_t    int_least8_t;
-typedef int16_t   int_least16_t;
-typedef int32_t   int_least32_t;
-typedef int64_t   int_least64_t;
-typedef uint8_t   uint_least8_t;
-typedef uint16_t  uint_least16_t;
-typedef uint32_t  uint_least32_t;
-typedef uint64_t  uint_least64_t;
-
-// 7.18.1.3 Fastest minimum-width integer types
-typedef int8_t    int_fast8_t;
-typedef int16_t   int_fast16_t;
-typedef int32_t   int_fast32_t;
-typedef int64_t   int_fast64_t;
-typedef uint8_t   uint_fast8_t;
-typedef uint16_t  uint_fast16_t;
-typedef uint32_t  uint_fast32_t;
-typedef uint64_t  uint_fast64_t;
-
 // 7.18.1.4 Integer types capable of holding object pointers
 #ifdef _WIN64 // [
    typedef __int64           intptr_t;


### PR DESCRIPTION
- Add appveyor compilation on Python 3.5, 3.6, 32 and 64 bits
- Remove unused typedef