### PR TITLE
Support JPEG 2000 format

### DIFF
--- a/fabio/fabioformats.py
+++ b/fabio/fabioformats.py
@@ -34,7 +34,7 @@ __author__ = "Valentin Valls"
 __contact__ = "valentin.valls@esrf.eu"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
-__date__ = "25/07/2017"
+__date__ = "27/07/2017"
 __status__ = "stable"
 __docformat__ = 'restructuredtext'
 
@@ -71,6 +71,7 @@ from . import hdf5image  # noqa
 from . import fit2dimage  # noqa
 from . import speimage  # noqa
 from . import jpegimage  # noqa
+from . import jpeg2kimage  # noqa
 
 
 def get_all_classes():

--- a/fabio/jpeg2kimage.py
+++ b/fabio/jpeg2kimage.py
@@ -1,0 +1,159 @@
+# coding: utf-8
+#
+#    Project: FabIO X-ray image reader
+#
+#    Copyright (C) 2010-2016 European Synchrotron Radiation Facility
+#                       Grenoble, France
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+"""
+FabIO class for dealing with JPEG 2000 images.
+"""
+
+from __future__ import with_statement, print_function, division
+
+__authors__ = ["Valentin Valls"]
+__date__ = "28/07/2017"
+__license__ = "MIT"
+__copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
+__status__ = "stable"
+
+import logging
+logger = logging.getLogger(__name__)
+
+try:
+    import PIL
+except ImportError:
+    PIL = None
+
+try:
+    import glymur
+except ImportError:
+    glymur = None
+
+
+from .fabioimage import FabioImage
+from .fabioutils import OrderedDict
+from .utils import pilutils
+
+
+class Jpeg2KImage(FabioImage):
+    """
+    Images in JPEG 2000 format.
+
+    It uses PIL or glymur libraries.
+    """
+    DESCRIPTION = "JPEG 2000 format"
+
+    DEFAULT_EXTENTIONS = ["jp2", "jpx", "j2k", "jpf", "jpg2"]
+
+    _need_a_seek_to_read = True
+
+    def __init__(self, *args, **kwds):
+        """ Tifimage constructor adds an nbits member attribute """
+        self.nbits = None
+        FabioImage.__init__(self, *args, **kwds)
+        self.lib = ""
+
+        self._decoders = OrderedDict()
+        if PIL is not None:
+            self._decoders["PIL"] = self._readWithPil
+        if glymur is not None:
+            self._decoders["glymur"] = self._readWithGlymur
+
+    def _readWithPil(self, filename, infile):
+        """Read data using PIL"""
+        self.pilimage = PIL.Image.open(infile)
+        data = pilutils.get_numpy_array(self.pilimage)
+        self.data = data
+
+        if self.pilimage and self.pilimage.info:
+            for k, v in self.pilimage.info.items():
+                self.header[k] = v
+
+        print(self.data)
+
+    def _loadGlymurImage(self, filename, infile):
+        """
+        Hack to use Glymur with Python file object
+
+        This code was tested with all release 0.8.x
+        """
+        # image = glymur.Jp2k(filename)
+        # inject a shape  to avoid calling the read function
+        if not glymur.__version__.startswith("0.8."):
+            raise IOError("Glymur version %s is not supported" % glymur.__version__)
+
+        image = glymur.Jp2k(filename=filename, shape=(1, 1))
+
+        # Move to the end of the file to know the size
+        infile.seek(0, 2)
+        length = infile.tell()
+        infile.seek(0)
+
+        # initialize what it should already be done
+        image.length = length
+        image._shape = None
+        # It is not the only one format supported by Glymur
+        # but it is a simplification
+        image._codec_format = glymur.lib.openjp2.CODEC_JP2
+
+        # parse the data
+        image.box = image.parse_superbox(infile)
+        try:
+            image._validate()
+        except Exception:
+            logger.debug("Backtrace", exc_info=True)
+            raise IOError("File %s is not a valid format" % filename)
+
+        # Now the image can be used normaly
+        return image
+
+    def _readWithGlymur(self, filename, infile):
+        """Read data using Glymur"""
+        image = self._loadGlymurImage(filename, infile)
+        self.data = image.read()
+
+    def read(self, filename, frame=None):
+        infile = self._open(filename, "rb")
+        self.data = None
+
+        for name, read in self._decoders.items():
+            try:
+                infile.seek(0)
+                read(filename, infile)
+                self.lib = name
+                break
+
+            except IOError as e:
+                self.data = None
+                self.header = OrderedDict()
+                logger.debug("Error while using %s library: %s" % (name, e), exc_info=True)
+                pass
+
+        if self.data is None:
+            infile.seek(0)
+            raise IOError("No decoder available for the file %s." % filename)
+        self.resetvals()
+        return self
+
+
+jpeg2kimage = Jpeg2KImage

--- a/fabio/openimage.py
+++ b/fabio/openimage.py
@@ -91,6 +91,8 @@ MAGIC_NUMBERS = [
     (b"\xFF\xD8\xFF\xE0", "jpeg"),
     # Exif format
     (b"\xFF\xD8\xFF\xE1", "jpeg"),
+    # JPEG 2000 (from RFC 3745)
+    (b"\x00\x00\x00\x0C\x6A\x50\x20\x20\x0D\x0A\x87\x0A", "jpeg2k"),
 ]
 
 

--- a/fabio/test/testjpeg2kimage.py
+++ b/fabio/test/testjpeg2kimage.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+#    Project: Fable Input Output
+#             https://github.com/silx-kit/fabio
+#
+#    Copyright (C) European Synchrotron Radiation Facility, Grenoble, France
+#
+#    Principal author:       Jérôme Kieffer (Jerome.Kieffer@ESRF.eu)
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+"""
+Test JPEG format
+"""
+
+from __future__ import print_function, with_statement, division, absolute_import
+
+import sys
+import unittest
+import numpy
+try:
+    from PIL import Image
+except ImportError:
+    Image = None
+
+from .utilstest import UtilsTest
+
+logger = UtilsTest.get_logger(__file__)
+fabio = sys.modules["fabio"]
+from .. import jpeg2kimage
+
+
+def isPilUsable():
+    if jpeg2kimage.PIL is None:
+        return False
+    try:
+        jpeg2kimage.PIL.Image.frombytes("1", (2, 2), b"", decoder_name='jpeg2k')
+    except Exception as e:
+        if e.args[0] == "decoder jpeg2k not available":
+            return False
+    return True
+
+
+def isGlymurUsable():
+    return jpeg2kimage.glymur is not None
+
+
+class TestJpeg2KImage(unittest.TestCase):
+    """Test the class format"""
+
+    def setUp(self):
+        if not isPilUsable() and not isGlymurUsable():
+            self.skipTest("PIL nor glymur are available")
+
+    def loadImage(self, filename):
+        image_format = jpeg2kimage.Jpeg2KImage()
+        image = image_format.read(filename)
+        return image
+
+    def test_open_uint8(self):
+        filename = "binned_data_uint8.jp2"
+        filename = UtilsTest.getimage(filename + ".bz2")[:-4]
+        image = self.loadImage(filename)
+        self.assertEqual(image.data.shape, (120, 120))
+        self.assertEqual(image.data.dtype, numpy.uint8)
+
+    def test_open_uint16(self):
+        filename = "binned_data_uint16.jp2"
+        filename = UtilsTest.getimage(filename + ".bz2")[:-4]
+        image_format = jpeg2kimage.Jpeg2KImage()
+        image = image_format.read(filename)
+        self.assertEqual(image.data.shape, (120, 120))
+        self.assertEqual(image.data.dtype, numpy.uint16)
+
+    def test_open_wrong_format(self):
+        filename = "MultiFrame.edf"
+        filename = UtilsTest.getimage(filename + ".bz2")[:-4]
+        image_format = jpeg2kimage.Jpeg2KImage()
+        try:
+            _image = image_format.read(filename)
+            self.fail()
+        except IOError:
+            pass
+
+    def test_open_missing_file(self):
+        filename = "___missing_file___.___"
+        image_format = jpeg2kimage.Jpeg2KImage()
+        try:
+            _image = image_format.read(filename)
+            self.fail()
+        except IOError:
+            pass
+
+
+class TestJpeg2KImage_PIL(TestJpeg2KImage):
+    """Test the class format using a specific decoder"""
+
+    def setUp(self):
+        if not isPilUsable() and not isGlymurUsable():
+            self.skipTest("PIL is not available")
+
+    @classmethod
+    def setUpClass(cls):
+        # Remove other decoders
+        cls.old = jpeg2kimage.glymur
+        jpeg2kimage.glymur = None
+
+    @classmethod
+    def tearDownClass(cls):
+        # Remove other decoders
+        jpeg2kimage.glymur = cls.old
+        cls.old = None
+
+
+class TestJpeg2KImage_glymur(TestJpeg2KImage):
+    """Test the class format using a specific decoder"""
+
+    def setUp(self):
+        if not isGlymurUsable():
+            self.skipTest("glymur is not available")
+
+    @classmethod
+    def setUpClass(cls):
+        # Remove other decoders
+        cls.old = jpeg2kimage.PIL
+        jpeg2kimage.PIL = None
+
+    @classmethod
+    def tearDownClass(cls):
+        # Remove other decoders
+        jpeg2kimage.PIL = cls.old
+        cls.old = None
+
+
+class TestJpeg2KImage_fabio(TestJpeg2KImage):
+    """Test the format inside the fabio framework"""
+
+    def loadImage(self, filename):
+        """Use the fabio API instead of using the image format"""
+        image = fabio.open(filename)
+        return image
+
+
+def suite():
+    loader = unittest.defaultTestLoader.loadTestsFromTestCase
+    testsuite = unittest.TestSuite()
+    testsuite.addTest(loader(TestJpeg2KImage))
+    testsuite.addTest(loader(TestJpeg2KImage_PIL))
+    testsuite.addTest(loader(TestJpeg2KImage_glymur))
+    testsuite.addTest(loader(TestJpeg2KImage_fabio))
+    return testsuite
+
+
+if __name__ == '__main__':
+    runner = unittest.TextTestRunner()
+    runner.run(suite())

--- a/run_tests.py
+++ b/run_tests.py
@@ -220,7 +220,9 @@ parser.add_argument("-m", "--memprofile", dest="memprofile",
                     help="Report memory profiling")
 parser.add_argument("-v", "--verbose", default=0,
                     action="count", dest="verbose",
-                    help="Increase verbosity")
+                    help="Increase verbosity. Option -v prints additional " +
+                         "INFO messages. Use -vv for full verbosity, " +
+                         "including debug messages and test help strings.")
 parser.add_argument(
     "test_name", nargs='*', default=(),
     help="Test names to run (Default: %s.test.suite)" % PROJECT_NAME)
@@ -228,12 +230,14 @@ options = parser.parse_args()
 sys.argv = [sys.argv[0]]
 
 
+test_verbosity = 1
 if options.verbose == 1:
     logging.root.setLevel(logging.INFO)
     logger.info("Set log level: INFO")
 elif options.verbose > 1:
     logging.root.setLevel(logging.DEBUG)
     logger.info("Set log level: DEBUG")
+    test_verbosity = 2
 
 
 if options.coverage:
@@ -279,7 +283,9 @@ PROJECT_PATH = module.__path__[0]
 if options.memprofile:
     runner = ProfileTestRunner()
 else:
-    runner = unittest.TextTestRunner()
+    runner = unittest.TextTestRunner(
+        buffer=test_verbosity <= 1,
+        verbosity=test_verbosity)
 
 logger.warning("Test %s %s from %s",
                PROJECT_NAME, PROJECT_VERSION, PROJECT_PATH)


### PR DESCRIPTION
The connector is supporting 2 decoders (PIL and glymur).
- PIL on debian 8 is not able to load JPG2000.
- The current glymur is not working with python file object. I tried to update the glymur API to make the result better, but right now our connector is very hackish. But i test it on all release version of the branch 0.8.x
- I upload 2 small files on www.silx.org (uint8 and uint16). Other formats are not supported.

Closes #120