### PR TITLE
Fix close with failing files

### DIFF
--- a/fabio/fabioimage.py
+++ b/fabio/fabioimage.py
@@ -46,7 +46,7 @@ __authors__ = ["Henning O. Sorensen", "Erik Knudsen", "Jon Wright", "Jérôme Ki
 __contact__ = "jerome.kieffer@esrf.fr"
 __license__ = "MIT"
 __copyright__ = "ESRF"
-__date__ = "29/08/2017"
+__date__ = "03/10/2017"
 
 import os
 import logging
@@ -139,10 +139,14 @@ class FabioImage(six.with_metaclass(FabioMeta, object)):
     def __enter__(self):
         return self
 
-    def __exit__(self, *arg):
+    def __exit__(self, exc_type, exc_val, tb):
         # TODO: inspace type, value and traceback
-        if self._file and not self._file.closed:
+        self.close()
+
+    def close(self):
+        if self._file is not None and not self._file.closed:
             self._file.close()
+        self._file = None
 
     def get_header_keys(self):
         return list(self.header.keys())

--- a/fabio/openimage.py
+++ b/fabio/openimage.py
@@ -178,6 +178,8 @@ def _openimage(filename):
             filename = url.path
         actual_filename = filename.split("::")[0]
 
+    filetype = None
+
     try:
         imo = FabioImage()
         byts = imo._open(actual_filename).read(18)
@@ -202,6 +204,10 @@ def _openimage(filename):
             import traceback
             traceback.print_exc()
             raise Exception("Fabio could not identify " + filename)
+
+    if filetype is None:
+        raise IOError("Fabio could not identify " + filename)
+
     klass_name = "".join(filetype) + 'image'
 
     try:

--- a/fabio/openimage.py
+++ b/fabio/openimage.py
@@ -186,10 +186,11 @@ def _openimage(filename):
         filetype = do_magic(byts, filename)
     except IOError as error:
         imo.close()
-        logger.error("%s: File probably does not exist", error)
+        logger.debug("%s: File probably does not exist", error)
         raise error
     except Exception:
         imo.close()
+        logger.debug("Backtrace", exc_info=True)
         try:
             file_obj = FilenameObject(filename=filename)
             if file_obj is None:
@@ -202,9 +203,7 @@ def _openimage(filename):
             filetype = file_obj.format
 
         except Exception as error:
-            logger.error(error)
-            import traceback
-            traceback.print_exc()
+            logger.debug("Backtrace", exc_info=True)
             raise IOError("Fabio could not identify " + filename)
 
     if filetype is None:
@@ -215,7 +214,7 @@ def _openimage(filename):
     try:
         obj = FabioImage.factory(klass_name)
     except (RuntimeError, Exception):
-        logger.error("Filetype not known %s %s" % (filename, klass_name))
+        logger.debug("Backtrace", exc_info=True)
         raise IOError("Filename %s can't be read as format %s" % (filename, klass_name))
 
     if url.scheme in ["nxs", "hdf5"] and filetype == "hdf5":

--- a/fabio/openimage.py
+++ b/fabio/openimage.py
@@ -178,18 +178,20 @@ def _openimage(filename):
             filename = url.path
         actual_filename = filename.split("::")[0]
 
-    filetype = None
-
     try:
         imo = FabioImage()
-        byts = imo._open(actual_filename).read(18)
-        filetype = do_magic(byts, filename)
+        with imo._open(actual_filename) as f:
+            magic_bytes = f.read(18)
     except IOError as error:
-        imo.close()
         logger.debug("%s: File probably does not exist", error)
         raise error
+    else:
+        imo = None
+
+    filetype = None
+    try:
+        filetype = do_magic(magic_bytes, filename)
     except Exception:
-        imo.close()
         logger.debug("Backtrace", exc_info=True)
         try:
             file_obj = FilenameObject(filename=filename)

--- a/fabio/openimage.py
+++ b/fabio/openimage.py
@@ -205,7 +205,7 @@ def _openimage(filename):
             logger.error(error)
             import traceback
             traceback.print_exc()
-            raise Exception("Fabio could not identify " + filename)
+            raise IOError("Fabio could not identify " + filename)
 
     if filetype is None:
         raise IOError("Fabio could not identify " + filename)
@@ -214,9 +214,9 @@ def _openimage(filename):
 
     try:
         obj = FabioImage.factory(klass_name)
-    except RuntimeError as err:
+    except (RuntimeError, Exception):
         logger.error("Filetype not known %s %s" % (filename, klass_name))
-        raise err
+        raise IOError("Filename %s can't be read as format %s" % (filename, klass_name))
 
     if url.scheme in ["nxs", "hdf5"] and filetype == "hdf5":
         obj.set_url(url)

--- a/fabio/openimage.py
+++ b/fabio/openimage.py
@@ -185,9 +185,11 @@ def _openimage(filename):
         byts = imo._open(actual_filename).read(18)
         filetype = do_magic(byts, filename)
     except IOError as error:
+        imo.close()
         logger.error("%s: File probably does not exist", error)
         raise error
-    except:
+    except Exception:
+        imo.close()
         try:
             file_obj = FilenameObject(filename=filename)
             if file_obj is None:

--- a/fabio/test/test_all.py
+++ b/fabio/test/test_all.py
@@ -70,6 +70,7 @@ from . import testfabioconvert
 from . import testjpegimage
 from . import testjpeg2kimage
 from . import testmpaimage
+from . import test_failing_files
 
 
 def suite():
@@ -109,6 +110,7 @@ def suite():
     testSuite.addTest(testjpegimage.suite())
     testSuite.addTest(testjpeg2kimage.suite())
     testSuite.addTest(testmpaimage.suite())
+    testSuite.addTest(test_failing_files.suite())
     return testSuite
 
 

--- a/fabio/test/test_failing_files.py
+++ b/fabio/test/test_failing_files.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+#    Project: Fable Input Output
+#             https://github.com/silx-kit/fabio
+#
+#    Copyright (C) European Synchrotron Radiation Facility, Grenoble, France
+#
+#    Principal author:       Jérôme Kieffer (Jerome.Kieffer@ESRF.eu)
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+"""Test failing files
+"""
+
+from __future__ import print_function, with_statement, division, absolute_import
+
+import unittest
+import os
+import io
+import fabio
+import tempfile
+import shutil
+import sys
+
+
+class TestFailingFiles(unittest.TestCase):
+    """Test failing files"""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.tmp_directory = tempfile.mkdtemp()
+        cls.createResources(cls.tmp_directory)
+
+    @classmethod
+    def createResources(cls, directory):
+
+        cls.txt_filename = os.path.join(directory, "test.txt")
+        f = io.open(cls.txt_filename, "w+t")
+        f.write(u"Kikoo")
+        f.close()
+
+        cls.missing_filename = os.path.join(directory, "test.missing")
+
+    @classmethod
+    def tearDownClass(cls):
+        shutil.rmtree(cls.tmp_directory)
+
+    def test_missing_file(self):
+        try:
+            fabio.open(self.missing_filename)
+            self.fail()
+        except IOError:
+            pass
+
+    def test_wrong_file(self):
+        try:
+            fabio.open(self.txt_filename)
+            self.fail()
+        except IOError:
+            pass
+
+
+def suite():
+    loadTests = unittest.defaultTestLoader.loadTestsFromTestCase
+    testsuite = unittest.TestSuite()
+    testsuite.addTest(loadTests(TestFailingFiles))
+    return testsuite
+
+
+if __name__ == '__main__':
+    runner = unittest.TextTestRunner()
+    runner.run(suite())


### PR DESCRIPTION
- Use with to open file for a short period of time
- Also clean up logs
- Clean up exception to only raise `IOError`

Closes #167