### PR TITLE
Improve EDF reader

### DIFF
--- a/fabio/compression.py
+++ b/fabio/compression.py
@@ -40,7 +40,7 @@ from __future__ import absolute_import, print_function, with_statement, division
 __author__ = "Jérôme Kieffer"
 __contact__ = "jerome.kieffer@esrf.eu"
 __license__ = "MIT"
-__date__ = "11/08/2017"
+__date__ = "06/10/2017"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
 
 
@@ -81,6 +81,25 @@ except ImportError:
 
 if sys.platform != "win32":
     WindowsError = OSError
+
+
+def is_incomplete_gz_block_exception(exception):
+    """True if the exception looks to be generated when a GZ block is
+    incomplete.
+
+    :rtype: bool
+    """
+    if six.PY2:
+        if isinstance(exception, IOError):
+            return "CRC check failed" in exception.args[0]
+    elif six.PY3:
+        version = sys.version_info[0:2]
+        if version == (3, 3):
+            import struct
+            return isinstance(exception, struct.error)
+        return isinstance(exception, EOFError)
+
+    return False
 
 
 def md5sum(blob):

--- a/fabio/edfimage.py
+++ b/fabio/edfimage.py
@@ -49,6 +49,7 @@ Authors:
 from __future__ import with_statement, print_function, absolute_import, division
 import os
 import re
+import string
 import logging
 logger = logging.getLogger(__name__)
 import numpy
@@ -160,12 +161,14 @@ class Frame(object):
         calcsize = 1
         self.dims = []
 
+        # Why would someone put null bytes in a header?
+        whitespace = string.whitespace + "\x00"
+
         for line in block.split(';'):
             if '=' in line:
                 key, val = line.split('=', 1)
-                # Why would someone put null bytes in a header?
-                key = key.replace("\x00", " ").strip()
-                self.header[key] = val.replace("\x00", " ").strip()
+                key = key.strip(whitespace)
+                self.header[key] = val.strip(whitespace)
                 self.capsHeader[key.upper()] = key
 
         # Compute image size

--- a/fabio/edfimage.py
+++ b/fabio/edfimage.py
@@ -679,16 +679,20 @@ class EdfImage(FabioImage):
         self.filename = fname
 
         infile = self._open(fname, "rb")
-        self._readheader(infile)
-        if frame is None:
-            pass
-        elif frame < self.nframes:
-            self = self.getframe(frame)
-        else:
-            logger.error("Reading file %s You requested frame %s but only %s frames are available", fname, frame, self.nframes)
-        self.resetvals()
-        # ensure the PIL image is reset
-        self.pilimage = None
+        try:
+            self._readheader(infile)
+            if frame is None:
+                pass
+            elif frame < self.nframes:
+                self = self.getframe(frame)
+            else:
+                logger.error("Reading file %s You requested frame %s but only %s frames are available", fname, frame, self.nframes)
+            self.resetvals()
+            # ensure the PIL image is reset
+            self.pilimage = None
+        except Exception as e:
+            infile.close()
+            raise e
         return self
 
     def swap_needed(self):

--- a/fabio/edfimage.py
+++ b/fabio/edfimage.py
@@ -150,11 +150,10 @@ class Frame(object):
         """
         Parse the header in some EDF format from an already open file
 
-        :param block: string representing the header block.
-        :type block: string, should be full ascii
+        :param str block: string representing the header block.
         :return: size of the binary blob
         """
-        # reset values ...
+        # reset values
         self.header = OrderedDict()
         self.capsHeader = {}
         self.size = None
@@ -189,7 +188,7 @@ class Frame(object):
             try:
                 dim2 = nice_int(self.header[self.capsHeader['DIM_2']])
             except ValueError:
-                logger.error("Unable to convert to integer Dim_3: %s %s" % (self.capsHeader["DIM_2"], self.header[self.capsHeader["DIM_2"]]))
+                logger.error("Unable to convert to integer Dim_2: %s %s" % (self.capsHeader["DIM_2"], self.header[self.capsHeader["DIM_2"]]))
             else:
                 calcsize *= dim2
                 self.dims.append(dim2)
@@ -575,6 +574,7 @@ class EdfImage(FabioImage):
         elif block[end_block: end_block + 2] == b"}\n":
             offset = end_block + 2 - len(block)
         else:
+            logger.warning("Malformed end of header block")
             offset = end_block + 2 - len(block)
 
         infile.seek(offset, os.SEEK_CUR)
@@ -1014,10 +1014,10 @@ class EdfImage(FabioImage):
                 self._frames[self.currentframe].bpp = _iVal
     bpp = property(getBpp, setBpp)
 
-    def getIncompleteData(self):
+    def isIncompleteData(self):
         return self._frames[self.currentframe].incomplete_data
 
-    incomplete_data = property(getIncompleteData)
+    incomplete_data = property(isIncompleteData)
 
 
 edfimage = EdfImage

--- a/fabio/fabioimage.py
+++ b/fabio/fabioimage.py
@@ -46,7 +46,7 @@ __authors__ = ["Henning O. Sorensen", "Erik Knudsen", "Jon Wright", "Jérôme Ki
 __contact__ = "jerome.kieffer@esrf.fr"
 __license__ = "MIT"
 __copyright__ = "ESRF"
-__date__ = "03/10/2017"
+__date__ = "06/10/2017"
 
 import os
 import logging
@@ -147,6 +147,14 @@ class FabioImage(six.with_metaclass(FabioMeta, object)):
         if self._file is not None and not self._file.closed:
             self._file.close()
         self._file = None
+
+    @property
+    def incomplete_file(self):
+        """Returns true if the readed file is not complete.
+
+        :rtype: bool
+        """
+        return False
 
     def get_header_keys(self):
         return list(self.header.keys())

--- a/fabio/test/test_failing_files.py
+++ b/fabio/test/test_failing_files.py
@@ -57,7 +57,7 @@ class TestFailingFiles(unittest.TestCase):
         f.write(b"\x00\xFF\x99" * 10)
         f.close()
 
-        cls.bad_edf2_filename = os.path.join(directory, "bad_edf.edf")
+        cls.bad_edf2_filename = os.path.join(directory, "bad_edf2.edf")
         f = io.open(cls.bad_edf2_filename, "w+b")
         f.write(b"\n{\n\n}\n")
         f.write(b"\xFF\x00\x99" * 10)

--- a/fabio/test/test_failing_files.py
+++ b/fabio/test/test_failing_files.py
@@ -94,12 +94,10 @@ class TestFailingFiles(unittest.TestCase):
         self.assertRaises(IOError, fabio.open, self.txt_filename)
 
     def test_wrong_edf(self):
-        with fabio.open(self.bad_edf_filename) as f:
-            self.assertEqual(f.getNbFrames(), 0)
+        self.assertRaises(IOError, fabio.open, self.bad_edf_filename)
 
     def test_wrong_edf2(self):
-        with fabio.open(self.bad_edf2_filename) as f:
-            self.assertEqual(f.getNbFrames(), 0)
+        self.assertRaises(IOError, fabio.open, self.bad_edf_filename)
 
     def test_wrong_msk(self):
         self.assertRaises(ValueError, fabio.open, self.bad_msk_filename)

--- a/fabio/test/test_failing_files.py
+++ b/fabio/test/test_failing_files.py
@@ -47,39 +47,33 @@ class TestFailingFiles(unittest.TestCase):
     def createResources(cls, directory):
 
         cls.txt_filename = os.path.join(directory, "test.txt")
-        f = io.open(cls.txt_filename, "w+t")
-        f.write(u"Kikoo")
-        f.close()
+        with io.open(cls.txt_filename, "w+t") as f:
+            f.write(u"Kikoo")
 
         cls.bad_edf_filename = os.path.join(directory, "bad_edf.edf")
-        f = io.open(cls.bad_edf_filename, "w+b")
-        f.write(b"\r{")
-        f.write(b"\x00\xFF\x99" * 10)
-        f.close()
+        with io.open(cls.bad_edf_filename, "w+b") as f:
+            f.write(b"\r{")
+            f.write(b"\x00\xFF\x99" * 10)
 
         cls.bad_edf2_filename = os.path.join(directory, "bad_edf2.edf")
-        f = io.open(cls.bad_edf2_filename, "w+b")
-        f.write(b"\n{\n\n}\n")
-        f.write(b"\xFF\x00\x99" * 10)
-        f.close()
+        with io.open(cls.bad_edf2_filename, "w+b") as f:
+            f.write(b"\n{\n\n}\n")
+            f.write(b"\xFF\x00\x99" * 10)
 
         cls.bad_msk_filename = os.path.join(directory, "bad_msk.msk")
-        f = io.open(cls.bad_msk_filename, "w+b")
-        f.write(b'M\x00\x00\x00A\x00\x00\x00S\x00\x00\x00K\x00\x00\x00')
-        f.write(b"\x00\xFF\x99" * 10)
-        f.close()
+        with io.open(cls.bad_msk_filename, "w+b") as f:
+            f.write(b'M\x00\x00\x00A\x00\x00\x00S\x00\x00\x00K\x00\x00\x00')
+            f.write(b"\x00\xFF\x99" * 10)
 
         cls.bad_dm3_filename = os.path.join(directory, "bad_dm3.dm3")
-        f = io.open(cls.bad_dm3_filename, "w+b")
-        f.write(b'\x00\x00\x00\x03')
-        f.write(b"\x00\xFF\x99" * 10)
-        f.close()
+        with io.open(cls.bad_dm3_filename, "w+b") as f:
+            f.write(b'\x00\x00\x00\x03')
+            f.write(b"\x00\xFF\x99" * 10)
 
         cls.bad_npy_filename = os.path.join(directory, "bad_numpy.npy")
-        f = io.open(cls.bad_npy_filename, "w+b")
-        f.write(b"\x93NUMPY")
-        f.write(b"\x00\xFF\x99" * 10)
-        f.close()
+        with io.open(cls.bad_npy_filename, "w+b") as f:
+            f.write(b"\x93NUMPY")
+            f.write(b"\x00\xFF\x99" * 10)
 
         cls.missing_filename = os.path.join(directory, "test.missing")
 

--- a/fabio/test/testedfimage.py
+++ b/fabio/test/testedfimage.py
@@ -199,18 +199,11 @@ class TestEdfCompressedData(unittest.TestCase):
         refFile = "edfUncompressed_U16.edf"
         gzippedFile = "edfGzip_U16.edf"
         compressedFile = "edfCompressed_U16.edf"
-        try:
-            ref.read(os.path.join(self.im_dir, refFile))
-        except:
-            raise RuntimeError("Cannot read image Uncompressed image %s" % refFile)
-        try:
-            gzipped.read(os.path.join(self.im_dir, gzippedFile))
-        except:
-            raise RuntimeError("Cannot read image gzippedFile image %s" % gzippedFile)
-        try:
-            compressed.read(os.path.join(self.im_dir, compressedFile))
-        except:
-            raise RuntimeError("Cannot read image compressedFile image %s" % compressedFile)
+
+        ref.read(os.path.join(self.im_dir, refFile))
+        gzipped.read(os.path.join(self.im_dir, gzippedFile))
+        compressed.read(os.path.join(self.im_dir, compressedFile))
+
         self.assertEqual((ref.data - gzipped.data).max(), 0, "Gzipped data block is correct")
         self.assertEqual((ref.data - compressed.data).max(), 0, "Zlib compressed data block is correct")
 
@@ -227,57 +220,43 @@ class TestEdfMultiFrame(unittest.TestCase):
         self.ref = edfimage()
         self.frame0 = edfimage()
         self.frame1 = edfimage()
-        try:
-            self.ref.read(self.multiFrameFilename)
-        except:
-            raise RuntimeError("Cannot read image multiFrameFilename image %s" % self.multiFrameFilename)
-        try:
-            self.frame0.read(self.Frame0Filename)
-        except:
-            raise RuntimeError("Cannot read image Frame0File image %s" % self.Frame0File)
-        try:
-            self.frame1.read(self.Frame1Filename)
-        except:
-            raise RuntimeError("Cannot read image Frame1File image %s" % self.Frame1File)
+
+        self.ref.read(self.multiFrameFilename)
+        self.frame0.read(self.Frame0Filename)
+        self.frame1.read(self.Frame1Filename)
 
     def tearDown(self):
         unittest.TestCase.tearDown(self)
         self.multiFrameFilename = self.Frame0Filename = self.Frame1Filename = self.ref = self.frame0 = self.frame1 = None
 
     def test_getFrame_multi(self):
-        """testedfmultiframe.test_getFrame_multi"""
         self.assertEqual((self.ref.data - self.frame0.data).max(), 0, "getFrame_multi: Same data for frame 0")
         f1_multi = self.ref.getframe(1)
-#        logger.warning("f1_multi.header=%s\nf1_multi.data=  %s" % (f1_multi.header, f1_multi.data))
+        # logger.warning("f1_multi.header=%s\nf1_multi.data=  %s" % (f1_multi.header, f1_multi.data))
         self.assertEqual((f1_multi.data - self.frame1.data).max(), 0, "getFrame_multi: Same data for frame 1")
 
     def test_getFrame_mono(self):
-        "testedfmultiframe.test_getFrame_mono"
         self.assertEqual((self.ref.data - self.frame0.data).max(), 0, "getFrame_mono: Same data for frame 0")
         f1_mono = self.frame0.getframe(1)
         self.assertEqual((f1_mono.data - self.frame1.data).max(), 0, "getFrame_mono: Same data for frame 1")
 
     def test_next_multi(self):
-        """testedfmultiframe.test_getFrame_mono"""
         self.assertEqual((self.ref.data - self.frame0.data).max(), 0, "next_multi: Same data for frame 0")
         next_ = self.ref.next()
         self.assertEqual((next_.data - self.frame1.data).max(), 0, "next_multi: Same data for frame 1")
 
     def text_next_mono(self):
-        "testedfmultiframe.text_next_mono"
         self.assertEqual((self.ref.data - self.frame0.data).max(), 0, "next_mono: Same data for frame 0")
         next_ = self.frame0.next()
         self.assertEqual((next_.data - self.frame1.data).max(), 0, "next_mono: Same data for frame 1")
 
     def test_previous_multi(self):
-        """testedfmultiframe.test_previous_multi"""
         f1 = self.ref.getframe(1)
         self.assertEqual((f1.data - self.frame1.data).max(), 0, "previous_multi: Same data for frame 1")
         f0 = f1.previous()
         self.assertEqual((f0.data - self.frame1.data).max(), 0, "previous_multi: Same data for frame 0")
 
     def test_previous_mono(self):
-        "testedfmultiframe.test_previous_mono"
         f1 = self.ref.getframe(1)
         self.assertEqual((f1.data - self.frame1.data).max(), 0, "previous_mono: Same data for frame 1")
         prev = self.frame1.previous()
@@ -286,7 +265,7 @@ class TestEdfMultiFrame(unittest.TestCase):
     def test_openimage_multiframes(self):
         "test if openimage can directly read first or second frame of a multi-frame"
         self.assertEqual((fabio.open(self.multiFrameFilename).data - self.frame0.data).max(), 0, "openimage_multiframes: Same data for default ")
-#         print(fabio.open(self.multiFrameFilename, 0).data)
+        # print(fabio.open(self.multiFrameFilename, 0).data)
         self.assertEqual((fabio.open(self.multiFrameFilename, 0).data - self.frame0.data).max(), 0, "openimage_multiframes: Same data for frame 0")
         self.assertEqual((fabio.open(self.multiFrameFilename, 1).data - self.frame1.data).max(), 0, "openimage_multiframes: Same data for frame 1")
 

--- a/fabio/test/testedfimage.py
+++ b/fabio/test/testedfimage.py
@@ -567,32 +567,6 @@ class TestBadGzFiles(TestBadFiles):
         # Not a gzipped file
         self.assertRaises(IOError, super(TestBadGzFiles, self).test_wrong_magic)
 
-    def get_incomplete_gz_block_exception(self):
-        if six.PY2:
-            return IOError
-        elif six.PY3:
-            version = sys.version_info[0:2]
-            if version == (3, 3):
-                import struct
-                return struct.error
-            return EOFError
-
-    def test_half_header(self):
-        exception = self.get_incomplete_gz_block_exception()
-        self.assertRaises(exception, super(TestBadGzFiles, self).test_half_header)
-
-    def test_header_with_half_data(self):
-        exception = self.get_incomplete_gz_block_exception()
-        self.assertRaises(exception, super(TestBadGzFiles, self).test_header_with_half_data)
-
-    def test_full_frame_plus_half_header(self):
-        exception = self.get_incomplete_gz_block_exception()
-        self.assertRaises(exception, super(TestBadGzFiles, self).test_full_frame_plus_half_header)
-
-    def test_full_frame_plus_header_with_half_data(self):
-        exception = self.get_incomplete_gz_block_exception()
-        self.assertRaises(exception, super(TestBadGzFiles, self).test_full_frame_plus_header_with_half_data)
-
 
 def suite():
     loadTests = unittest.defaultTestLoader.loadTestsFromTestCase

--- a/fabio/test/testedfimage.py
+++ b/fabio/test/testedfimage.py
@@ -458,6 +458,7 @@ class TestBadFiles(unittest.TestCase):
 
         image = self.open(filename)
         self.assertEqual(image.nframes, 0)
+        self.assertTrue(image.incomplete_file)
 
     def test_wrong_magic(self):
         filename = os.path.join(self.tmp_directory, self.filename_template % str(self.id()))
@@ -475,6 +476,7 @@ class TestBadFiles(unittest.TestCase):
 
         image = self.open(filename)
         self.assertEqual(image.nframes, 0)
+        self.assertTrue(image.incomplete_file)
 
     def test_header_with_no_data(self):
         filename = os.path.join(self.tmp_directory, self.filename_template % str(self.id()))
@@ -483,6 +485,7 @@ class TestBadFiles(unittest.TestCase):
 
         image = self.open(filename)
         self.assertEqual(image.nframes, 0)
+        self.assertTrue(image.incomplete_file)
 
     def test_header_with_half_data(self):
         filename = os.path.join(self.tmp_directory, self.filename_template % str(self.id()))
@@ -491,10 +494,12 @@ class TestBadFiles(unittest.TestCase):
 
         image = self.open(filename)
         self.assertEqual(image.nframes, 1)
+        self.assertTrue(image.incomplete_file)
 
         frame = image
         self.assertEqual(frame.header["Image"], "1")
         self.assertEqual(frame.data[-1].sum(), 0)
+        self.assertTrue(frame.incomplete_data)
 
     def test_full_frame_plus_half_header(self):
         filename = os.path.join(self.tmp_directory, self.filename_template % str(self.id()))
@@ -503,10 +508,12 @@ class TestBadFiles(unittest.TestCase):
 
         image = self.open(filename)
         self.assertEqual(image.nframes, 1)
+        self.assertTrue(image.incomplete_file)
 
         frame = image
         self.assertEqual(frame.header["Image"], "1")
         self.assertEqual(frame.data[-1].sum(), 2560)
+        self.assertFalse(frame.incomplete_data)
 
     def test_full_frame_plus_header_with_no_data(self):
         filename = os.path.join(self.tmp_directory, self.filename_template % str(self.id()))
@@ -515,10 +522,12 @@ class TestBadFiles(unittest.TestCase):
 
         image = self.open(filename)
         self.assertEqual(image.nframes, 1)
+        self.assertTrue(image.incomplete_file)
 
         frame = image
         self.assertEqual(frame.header["Image"], "1")
         self.assertEqual(frame.data[-1].sum(), 2560)
+        self.assertFalse(frame.incomplete_data)
 
     def test_full_frame_plus_header_with_half_data(self):
         filename = os.path.join(self.tmp_directory, self.filename_template % str(self.id()))
@@ -527,13 +536,17 @@ class TestBadFiles(unittest.TestCase):
 
         image = self.open(filename)
         self.assertEqual(image.nframes, 2)
+        self.assertTrue(image.incomplete_file)
 
         frame = image.getframe(0)
         self.assertEqual(frame.header["Image"], "1")
         self.assertEqual(frame.data[-1].sum(), 2560)
+        self.assertFalse(frame.incomplete_data)
+
         frame = image.getframe(1)
         self.assertEqual(frame.header["Image"], "2")
         self.assertEqual(frame.data[-1].sum(), 0)
+        self.assertTrue(frame.incomplete_data)
 
 
 class TestBadGzFiles(TestBadFiles):

--- a/fabio/test/testedfimage.py
+++ b/fabio/test/testedfimage.py
@@ -456,9 +456,7 @@ class TestBadFiles(unittest.TestCase):
         f = io.open(filename, "wb")
         f.close()
 
-        image = self.open(filename)
-        self.assertEqual(image.nframes, 0)
-        self.assertTrue(image.incomplete_file)
+        self.assertRaises(IOError, self.open, filename)
 
     def test_wrong_magic(self):
         filename = os.path.join(self.tmp_directory, self.filename_template % str(self.id()))
@@ -466,17 +464,14 @@ class TestBadFiles(unittest.TestCase):
         f.write(six.b("\x10\x20\x30"))
         f.close()
 
-        image = self.open(filename)
-        self.assertEqual(image.nframes, 0)
+        self.assertRaises(IOError, self.open, filename)
 
     def test_half_header(self):
         filename = os.path.join(self.tmp_directory, self.filename_template % str(self.id()))
         size = self.header1 // 2
         self.copy_base(filename, size)
 
-        image = self.open(filename)
-        self.assertEqual(image.nframes, 0)
-        self.assertTrue(image.incomplete_file)
+        self.assertRaises(IOError, self.open, filename)
 
     def test_header_with_no_data(self):
         filename = os.path.join(self.tmp_directory, self.filename_template % str(self.id()))
@@ -484,7 +479,7 @@ class TestBadFiles(unittest.TestCase):
         self.copy_base(filename, size)
 
         image = self.open(filename)
-        self.assertEqual(image.nframes, 0)
+        self.assertIn(image.nframes, [0, 1])
         self.assertTrue(image.incomplete_file)
 
     def test_header_with_half_data(self):
@@ -521,7 +516,7 @@ class TestBadFiles(unittest.TestCase):
         self.copy_base(filename, size)
 
         image = self.open(filename)
-        self.assertEqual(image.nframes, 1)
+        self.assertIn(image.nframes, [1, 2])
         self.assertTrue(image.incomplete_file)
 
         frame = image
@@ -562,10 +557,6 @@ class TestBadGzFiles(TestBadFiles):
     def write_data(cls, fd):
         with GzipFile(fileobj=fd, mode="wb") as gzfd:
             TestBadFiles.write_data(gzfd)
-
-    def test_wrong_magic(self):
-        # Not a gzipped file
-        self.assertRaises(IOError, super(TestBadGzFiles, self).test_wrong_magic)
 
 
 def suite():


### PR DESCRIPTION
This PR will try to improve reading multiframe EDF containing many GZ blocks.

- Create unittest to test bad files containing incomplete frames
- Create unittest to test bad files containing incomplete frames with GZ blocks
- Clean up the parsing of the headers
- Remove `measure_size` which occurs slow down when reading files using a lot of GZ blocks in Python2
- Add API to know if file is incomplete or frame is incomplete (maybe we can use another API: `is_valid` or thing like that)
- Allow to read part of file using incomplete GZ blocks (the last one)
- Remove some `replace`
- Empty edf or containing a single frame with bad header raises now an `IOError`

Relative to https://github.com/silx-kit/silx/issues/1168

Testing massively compressed files from ID01 using Python2, the result is fine
```
In [3]: filename = "../data/edf/id01_carsten_richter/kmap00001.edf.gz"

In [6]: %timeit ii = EdfFile(filename, fastedf=True); (ii.GetData(i) for i in range(ii.NumImages))
1 loop, best of 3: 22.2 s per loop

In [8]: %timeit ii = fabio.edfimage.EdfImage(); ii.read(filename); (ii.getframe(i) for i in range(ii.nframes))
1 loop, best of 3: 22.8 s per loop
```

Here is the result to compare the computation using a smaller  file (200KB) with 1024 GZ-blocks of 1024 frames of images of 32x32. The result is the sum of the computation using 100 iterations.
```
EdfFile
Open: 7.98
Read: 3.87
Sum: 11.85

FabIO before the patch
Open: 36.41
Read: 1.47
Sum: 37.88

FabIO after the patch
Open: 11.87
Read: 1.47
Sum: 13.34
```