### PR TITLE
Move codec registry from FabioImage class to fabioformat

### DIFF
--- a/fabio/__init__.py
+++ b/fabio/__init__.py
@@ -30,7 +30,7 @@ __author__ = "Jérôme Kieffer"
 __contact__ = "Jerome.Kieffer@ESRF.eu"
 __license__ = "GPLv3+"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
-__date__ = "16/01/2018"
+__date__ = "12/06/2018"
 __status__ = "stable"
 
 
@@ -49,9 +49,18 @@ try:
 except ImportError:
     raise RuntimeError("Do NOT use %s from its sources: build it and use the built version" % project)
 
+from . import fabioformats as _fabioformats
+
+# provide a global fabio API
+register = _fabioformats.register
+factory = _fabioformats.factory
+
+# feed the library with all the available formats
+_fabioformats.register_default_formats()
+
 from . import fabioimage
-factory = fabioimage.FabioImage.factory
 from . import openimage
+
 from .fabioutils import COMPRESSORS, jump_filename, FilenameObject, \
     previous_filename, next_filename, deconstruct_filename, \
     extract_filenumber, getnum, construct_filename, exists
@@ -86,6 +95,7 @@ def register(codec_class):
             pass
     """
     assert(issubclass(codec_class, fabioimage.FabioImage))
+    _fabioformats.register(codec_class)
     return codec_class
 
 

--- a/fabio/app/convert.py
+++ b/fabio/app/convert.py
@@ -35,7 +35,7 @@ from __future__ import with_statement, print_function
 __author__ = "Valentin Valls"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
 __licence__ = "MIT"
-__date__ = "31/07/2017"
+__date__ = "12/06/2018"
 __status__ = "production"
 
 import logging
@@ -266,7 +266,7 @@ def is_format_supported(format_name):
     :rtype: bool
     """
     try:
-        fabio.fabioimage.FabioImage.factory(format_name)
+        fabio.factory(format_name)
         return True
     except RuntimeError:
         logger.debug("Backtrace", exc_info=True)

--- a/fabio/fabioformats.py
+++ b/fabio/fabioformats.py
@@ -185,6 +185,8 @@ def _get_extension_mapping():
     if _extension_cache is None:
         _extension_cache = {}
         for codec in get_all_classes():
+            if not hasattr(codec, "DEFAULT_EXTENSIONS"):
+                continue
             for ext in codec.DEFAULT_EXTENSIONS:
                 if ext not in _extension_cache:
                     _extension_cache[ext] = []

--- a/fabio/fabioformats.py
+++ b/fabio/fabioformats.py
@@ -34,7 +34,7 @@ __author__ = "Valentin Valls"
 __contact__ = "valentin.valls@esrf.eu"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
-__date__ = "27/07/2017"
+__date__ = "12/06/2018"
 __status__ = "stable"
 __docformat__ = 'restructuredtext'
 
@@ -42,44 +42,95 @@ import logging
 _logger = logging.getLogger(__name__)
 
 from . import fabioimage
+from .fabioutils import OrderedDict
 
-# Note: The order of the import is important for the import sequence
-from . import edfimage  # noqa
-from . import adscimage  # noqa
-from . import tifimage  # noqa
-from . import marccdimage  # noqa
-from . import mar345image  # noqa
-from . import fit2dmaskimage  # noqa
-from . import brukerimage  # noqa
-from . import bruker100image  # noqa
-from . import pnmimage  # noqa
-from . import GEimage  # noqa
-from . import OXDimage  # noqa
-from . import dm3image  # noqa
-from . import HiPiCimage  # noqa
-from . import pilatusimage  # noqa
-from . import fit2dspreadsheetimage  # noqa
-from . import kcdimage  # noqa
-from . import cbfimage  # noqa
-from . import xsdimage  # noqa
-from . import binaryimage  # noqa
-from . import pixiimage  # noqa
-from . import raxisimage  # noqa
-from . import numpyimage  # noqa
-from . import eigerimage  # noqa
-from . import hdf5image  # noqa
-from . import fit2dimage  # noqa
-from . import speimage  # noqa
-from . import jpegimage  # noqa
-from . import jpeg2kimage  # noqa
-from . import mpaimage  # noqa
+try:
+    import importlib
+    importer = importlib.import_module
+except ImportError:
+    def importer(module_name):
+        module = __import__(module_name)
+        # returns the leaf module, instead of the root module
+        names = module_name.split(".")
+        names.pop(0)
+        for name in names:
+            module = getattr(module, name)
+        return module
+
+
+_default_codecs = [
+    ("edfimage", "EdfImage"),
+    ("adscimage", "AdscImage"),
+    ("tifimage", "TifImage"),
+    ("marccdimage", "MarccdImage"),
+    ("mar345image", "Mar345Image"),
+    ("fit2dmaskimage", "Fit2dMaskImage"),
+    ("brukerimage", "BrukerImage"),
+    ("bruker100image", "Bruker100Image"),
+    ("pnmimage", "PnmImage"),
+    ("GEimage", "GeImage"),
+    ("OXDimage", "OxdImage"),
+    ("dm3image", "Dm3Image"),
+    ("HiPiCimage", "HipicImage"),
+    ("pilatusimage", "PilatusImage"),
+    ("fit2dspreadsheetimage", "Fit2dSpreadsheetImage"),
+    ("kcdimage", "KcdImage"),
+    ("cbfimage", "CbfImage"),
+    ("xsdimage", "XsdImage"),
+    ("binaryimage", "BinaryImage"),
+    ("pixiimage", "PixiImage"),
+    ("raxisimage", "RaxisImage"),
+    ("numpyimage", "NumpyImage"),
+    ("eigerimage", "EigerImage"),
+    ("hdf5image", "Hdf5Image"),
+    ("fit2dimage", "Fit2dImage"),
+    ("speimage", "SpeImage"),
+    ("jpegimage", "JpegImage"),
+    ("jpeg2kimage", "Jpeg2KImage"),
+    ("mpaimage", "MpaImage"),
+]
+"""List of relative module and class names for available formats in fabio.
+Order matter."""
+
+
+_registry = OrderedDict()
+"""Contains all registered codec classes indexed by codec name."""
+
+_extension_cache = None
+"""Cache extension mapping"""
+
+
+def register(codec_class):
+    """Register a class format to the core fabio library"""
+    global _extension_cache
+    if not issubclass(codec_class, fabioimage.FabioImage):
+        raise AssertionError("Expected subclass of FabioImage class but found %s" % type(codec_class))
+    _registry[codec_class.codec_name()] = codec_class
+    # clean u[p the cache
+    _extension_cache = None
+
+
+def register_default_formats():
+    """Register all available default image classes provided by fabio.
+
+    If a format is already registered, it will be overwriten
+    """
+    # we use __init__ rather than __new__ here because we want
+    # to modify attributes of the class *after* they have been
+    # created
+    for module_name, class_name in _default_codecs:
+        module = importer("fabio." + module_name)
+        codec_class = getattr(module, class_name)
+        if codec_class is None:
+            raise RuntimeError("Class name '%s' from mudule '%s' not found" % (class_name, module_name))
+        register(codec_class)
 
 
 def get_all_classes():
     """Returns the list of supported codec identified by there fabio classes.
 
     :rtype: list"""
-    return fabioimage.FabioImage.registry.values()
+    return _registry.values()
 
 
 def get_classes(reader=None, writer=None):
@@ -118,14 +169,10 @@ def get_class_by_name(format_name):
     :param str format_name: Format name, for example, "edfimage"
     :return: instance of the new class
     """
-    if format_name in fabioimage.FabioImage.registry:
-        return fabioimage.FabioImage.registry[format_name]
+    if format_name in _registry:
+        return _registry[format_name]
     else:
         return None
-
-
-_extension_cache = None
-"""Cache extension mapping"""
 
 
 def _get_extension_mapping():
@@ -171,3 +218,22 @@ def is_extension_supported(extension):
     mapping = _get_extension_mapping()
     extension = extension.lower()
     return extension in mapping
+
+
+def factory(name):
+    """Factory of image using name of the codec class.
+
+    :param str name: name of the class to instantiate
+    :return: an instance of the class
+    :rtype: fabio.fabioimage.FabioImage
+    """
+    name = name.lower()
+    obj = None
+    if name in _registry:
+        obj = _registry[name]()
+    else:
+        msg = ("FileType %s is unknown !, "
+               "please check if the filename exists or select one from %s" % (name, _registry.keys()))
+        _logger.debug(msg)
+        raise RuntimeError(msg)
+    return obj

--- a/fabio/fabioimage.py
+++ b/fabio/fabioimage.py
@@ -44,7 +44,7 @@ __authors__ = ["Henning O. Sorensen", "Erik Knudsen", "Jon Wright", "Jérôme Ki
 __contact__ = "jerome.kieffer@esrf.fr"
 __license__ = "MIT"
 __copyright__ = "ESRF"
-__date__ = "15/01/2018"
+__date__ = "12/06/2018"
 
 import os
 import logging
@@ -53,32 +53,11 @@ import tempfile
 logger = logging.getLogger(__name__)
 import numpy
 from . import fabioutils, converters
-from .fabioutils import six, OrderedDict
+from .fabioutils import OrderedDict
 from .utils import pilutils
 
 
-class FabioMeta(type):
-
-    @property
-    def DEFAULT_EXTENTIONS(self):
-        """
-        Compatibility with the wrong typo.
-
-        .. note:: Will be marked as deprecated for the following version 0.7.
-        """
-        return self.DEFAULT_EXTENSIONS
-
-    @DEFAULT_EXTENTIONS.setter
-    def DEFAULT_EXTENTIONS(self, extensions):
-        """
-        Compatibility with the wrong typo.
-
-        .. note:: Will be marked as deprecated for the following version 0.7.
-        """
-        self.DEFAULT_EXTENSIONS = extensions
-
-
-class FabioImage(six.with_metaclass(FabioMeta, object)):
+class FabioImage(object):
     """A common object for images in fable
 
     Contains a numpy array (.data) and dict of meta data (.header)

--- a/fabio/fabioimage.py
+++ b/fabio/fabioimage.py
@@ -70,6 +70,7 @@ class FabioImage(object):
     # List of header keys which are reserved by the file format
 
     @classmethod
+    @fabioutils.deprecated
     def factory(cls, name):
         """A kind of factory... for image_classes
 

--- a/fabio/fabioutils.py
+++ b/fabio/fabioutils.py
@@ -38,7 +38,7 @@ __author__ = "Jérôme Kieffer"
 __contact__ = "Jerome.Kieffer@ESRF.eu"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
-__date__ = "29/09/2017"
+__date__ = "12/06/2018"
 __status__ = "stable"
 __docformat__ = 'restructuredtext'
 
@@ -85,7 +85,11 @@ def deprecated(func):
         """
         decorator that deprecates the use of a function
         """
-        logger.warning("%s is Deprecated !!! %s" % (func.func_name, os.linesep.join([""] + traceback.format_stack()[:-1])))
+        if six.PY3:
+            func_name = func.__name__
+        else:
+            func_name = func.func_name
+        logger.warning("%s is Deprecated !!! %s" % (func_name, os.linesep.join([""] + traceback.format_stack()[:-1])))
         return func(*arg, **kw)
     return wrapper
 

--- a/fabio/openimage.py
+++ b/fabio/openimage.py
@@ -213,7 +213,7 @@ def _openimage(filename):
     klass_name = "".join(filetype) + 'image'
 
     try:
-        obj = FabioImage.factory(klass_name)
+        obj = fabioformats.factory(klass_name)
     except (RuntimeError, Exception):
         logger.debug("Backtrace", exc_info=True)
         raise IOError("Filename %s can't be read as format %s" % (filename, klass_name))

--- a/fabio/test/test_formats.py
+++ b/fabio/test/test_formats.py
@@ -46,6 +46,9 @@ from .. import fabioformats
 
 class TestRegistration(unittest.TestCase):
 
+    def test_not_existing(self):
+        self.assertIsNone(fabioformats.get_class_by_name("myformat0"))
+
     def test_annotation(self):
         @fabio.register
         class MyFormat1(fabio.fabioimage.FabioImage):

--- a/fabio/test/test_formats.py
+++ b/fabio/test/test_formats.py
@@ -46,6 +46,29 @@ from .. import fabioformats
 
 class TestRegistration(unittest.TestCase):
 
+    def test_fabio_factory(self):
+        image = fabio.factory("edfimage")
+        self.assertIsNotNone(image)
+
+    def test_fabio_factory_missing_format(self):
+        self.assertRaises(RuntimeError, fabio.factory, "foobarimage")
+
+    def test_fabioformats_factory(self):
+        image = fabioformats.factory("edfimage")
+        self.assertIsNotNone(image)
+
+    def test_fabioformats_factory_missing_format(self):
+        self.assertRaises(RuntimeError, fabioformats.factory, "foobarimage")
+
+    def test_deprecated_fabioimage_factory(self):
+        """Check that it is still working"""
+        image = fabio.fabioimage.FabioImage.factory("edfimage")
+        self.assertIsNotNone(image)
+
+    def test_deprecated_fabioimage_factory_missing_format(self):
+        """Check that it is still working"""
+        self.assertRaises(RuntimeError, fabio.fabioimage.FabioImage.factory, "foobarimage")
+
     def test_not_existing(self):
         self.assertIsNone(fabioformats.get_class_by_name("myformat0"))
 


### PR DESCRIPTION
- Explicit registration of the available codecs
- Remove `registry` from `fabioimage.FabioImage` and move it to `fabioformats`
- Remove the FabioImage metaclass
- Test for the `fabio.register` function (check if adding a new format at runtime is working)
- Deprecate `FabioImage.factory`

It changes the behavior for people who are registering custom formats (now you have to call explicitly `fabio.register(MyImageCodecClass))`. Or to use it as a decorator:

```
@fabio.register
class MyImageCodecClass(FabioImage):
    pass
```



Close #177