### PR TITLE
Proposal for fabio.register function before introducing the change

### DIFF
--- a/fabio/__init__.py
+++ b/fabio/__init__.py
@@ -30,7 +30,7 @@ __author__ = "Jérôme Kieffer"
 __contact__ = "Jerome.Kieffer@ESRF.eu"
 __license__ = "GPLv3+"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
-__date__ = "27/07/2017"
+__date__ = "16/01/2018"
 __status__ = "stable"
 
 
@@ -61,6 +61,32 @@ filename_object = FilenameObject
 
 from .openimage import openimage as open
 from .openimage import openheader as openheader
+
+
+def register(codec_class):
+    """
+    Register a codec class with the set of formats supported by fabio.
+
+    It is a transitional function to prepare the next comming version of fabio.
+
+    - On the current fabio library, when a module is imported, all the formats
+        inheriting FabioImage are automatically registred. And this function is
+        doing nothing.
+    - On the next fabio library. Importing a module containing classes
+        inheriting FabioImage will not be registered. And this function will
+        register the class.
+
+    The following source code will then provide the same behaviour on both
+    fabio versions, and it is recommended to use it.
+
+    .. code-block:: python
+
+        @fabio.register
+        class MyCodec(fabio.fabioimage.FabioImage):
+            pass
+    """
+    assert(issubclass(codec_class, fabioimage.FabioImage))
+    return codec_class
 
 
 def tests():

--- a/fabio/test/test_all.py
+++ b/fabio/test/test_all.py
@@ -72,6 +72,7 @@ from . import testjpeg2kimage
 from . import testmpaimage
 from . import testdm3image
 from . import test_failing_files
+from . import test_formats
 
 
 def suite():
@@ -113,6 +114,7 @@ def suite():
     testSuite.addTest(testmpaimage.suite())
     testSuite.addTest(testdm3image.suite())
     testSuite.addTest(test_failing_files.suite())
+    testSuite.addTest(test_formats.suite())
     return testSuite
 
 

--- a/fabio/test/test_formats.py
+++ b/fabio/test/test_formats.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+#    Project: Fable Input Output
+#             https://github.com/silx-kit/fabio
+#
+#    Copyright (C) European Synchrotron Radiation Facility, Grenoble, France
+#
+#    Principal author:       Jérôme Kieffer (Jerome.Kieffer@ESRF.eu)
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+"""
+# Unit tests
+
+# builds on stuff from ImageD11.test.testpeaksearch
+28/11/2014
+"""
+from __future__ import print_function, with_statement, division, absolute_import
+import unittest
+import sys
+import os
+
+
+if __name__ == '__main__':
+    import pkgutil
+    __path__ = pkgutil.extend_path([os.path.dirname(__file__)], "fabio.test")
+from .utilstest import UtilsTest
+
+
+logger = UtilsTest.get_logger(__file__)
+fabio = sys.modules["fabio"]
+from .. import fabioformats
+
+
+class TestRegistration(unittest.TestCase):
+
+    def test_annotation(self):
+        @fabio.register
+        class MyFormat1(fabio.fabioimage.FabioImage):
+            pass
+        self.assertIsNotNone(fabioformats.get_class_by_name("myformat1"))
+
+    def test_function(self):
+        class MyFormat2(fabio.fabioimage.FabioImage):
+            pass
+        fabio.register(MyFormat2)
+        self.assertIsNotNone(fabioformats.get_class_by_name("myformat2"))
+
+
+def suite():
+    loadTests = unittest.defaultTestLoader.loadTestsFromTestCase
+    testsuite = unittest.TestSuite()
+    testsuite.addTest(loadTests(TestRegistration))
+    return testsuite
+
+
+if __name__ == '__main__':
+    runner = unittest.TextTestRunner()
+    runner.run(suite())


### PR DESCRIPTION
This PR create an empty function `fabio.register` for the release of fabio 0.6. It allow people to patch there code before the change the coming change of the behaviour in fabio 0.7.

That's just a proposal in case we do not apply the change now.