### PR TITLE
TiffIO: Allow custom description and software tag

### DIFF
--- a/fabio/TiffIO.py
+++ b/fabio/TiffIO.py
@@ -676,7 +676,7 @@ class TiffIO(object):
                 readout = numpy.fromstring(fd.read(nBytes), dtype)
             if hasattr(nBits, 'index'):
                 readout.shape = -1, nColumns, len(nBits)
-            elif info['colormap'] is not None:
+            elif colormap is not None:
                 readout = colormap[readout]
             else:
                 readout.shape = -1, nColumns
@@ -727,7 +727,7 @@ class TiffIO(object):
                         readout = numpy.fromstring(bufferBytes, dtype)
                     if hasattr(nBits, 'index'):
                         readout.shape = -1, nColumns, len(nBits)
-                    elif info['colormap'] is not None:
+                    elif colormap is not None:
                         readout = colormap[readout]
                         readout.shape = -1, nColumns, 3
                     else:
@@ -1244,9 +1244,9 @@ if __name__ == "__main__":
     for i in range(tif.getNumberOfImages()):
         info = tif.getInfo(i)
         for key in info:
-            if key not in ["colormap"]:
+            if key != 'colormap':
                 print("%s = %s" % (key, info[key]))
-            elif info['colormap'] is not None:
+            elif info[key] is not None:
                 print("RED   %s = %s" % (key, info[key][0:10, 0]))
                 print("GREEN %s = %s" % (key, info[key][0:10, 1]))
                 print("BLUE  %s = %s" % (key, info[key][0:10, 2]))

--- a/fabio/TiffIO.py
+++ b/fabio/TiffIO.py
@@ -786,12 +786,7 @@ class TiffIO(object):
 
         return image
 
-    def writeImage(self, image0, info=None, software=None, date=None):
-        if software is None:
-            software = 'PyMca.TiffIO'
-        # if date is None:
-        #    date = time.ctime()
-
+    def writeImage(self, image0, info=None, software='PyMca.TiffIO', date=None):
         self.__makeSureFileIsOpen()
         fd = self.fd
         # prior to do anything, perform some tests
@@ -855,10 +850,10 @@ class TiffIO(object):
         fd.seek(0, os.SEEK_END)
 
         # get the description information from the input information
-        if info is None:
+        if not isinstance(info, dict):
             description = info
         else:
-            description = "%s" % ""
+            description = ""
             for key in info.keys():
                 description += "%s=%s\n" % (key, info[key])
 

--- a/fabio/TiffIO.py
+++ b/fabio/TiffIO.py
@@ -434,30 +434,25 @@ class TiffIO(object):
         else:
             model = None
 
-        defaultSoftware = "Unknown Software"
-
+        software = None
         if TAG_SOFTWARE in tagIDList:
             software = self._readIFDEntry(TAG_SOFTWARE,
                                           tagIDList, fieldTypeList, nValuesList, valueOffsetList)
             if isinstance(software, (tuple, list)):
                 software = helpString.join(software)
         else:
-            software = defaultSoftware
-
-        if software == defaultSoftware:
             try:
                 if imageDescription.upper().startswith("IMAGEJ"):
                     software = imageDescription.split("=")[0]
             except:
                 pass
 
+        date = None
         if TAG_DATE in tagIDList:
             date = self._readIFDEntry(TAG_DATE,
                                       tagIDList, fieldTypeList, nValuesList, valueOffsetList)
             if type(date) in [type([1]), type((1,))]:
                 date = helpString.join(date)
-        else:
-            date = "Unknown Date"
 
         stripOffsets = self._readIFDEntry(TAG_STRIP_OFFSETS,
                                           tagIDList,
@@ -525,7 +520,7 @@ class TiffIO(object):
 
         infoDict = {}
         testString = 'PyMca'
-        if software.startswith(testString):
+        if software is not None and software.startswith(testString):
             # str to make sure python 2.x sees it as string and not unicode
             descriptionString = imageDescription
             # interpret the image description in terms of supplied


### PR DESCRIPTION
Allow tiff image without software tag and a description which is not a dict