### PR TITLE
EDF: clear capsHeader before update it

### DIFF
--- a/fabio/edfimage.py
+++ b/fabio/edfimage.py
@@ -366,6 +366,8 @@ class Frame(object):
         else:
             data = self.data
         fit2dMode = bool(fit2dMode)
+
+        self.capsHeader.clear()
         for key in self.header:
             KEY = key.upper()
             if KEY not in self.capsHeader:


### PR DESCRIPTION
If you (only) remove some reserved header (ex DIM_1) from a edf image, when you write this image an exception is raised: KeyError: u'Dim_1'