### PR TITLE
Clean up capsheader from EDF

### DIFF
--- a/fabio/edfimage.py
+++ b/fabio/edfimage.py
@@ -152,13 +152,10 @@ class Frame(object):
         else:
             self.iFrame = 0
 
-    @property
-    def capsHeader(self):
+    def _compute_capsheader(self):
         """
         Returns the mapping from capitalized keys of the header to the original
         keys.
-
-        This computation is not cached.
 
         :rtype: dict
         """
@@ -182,7 +179,7 @@ class Frame(object):
         self.dims = []
 
         if capsHeader is None:
-            capsHeader = self.capsHeader
+            capsHeader = self._compute_capsheader()
 
         # Compute image size
         if "SIZE" in capsHeader:
@@ -898,7 +895,7 @@ class EdfImage(FabioImage):
         return data[slice2]
 
     ############################################################################
-    # Properties definition for header, data, header_keys and capsHeader
+    # Properties definition for header, data, header_keys
     ############################################################################
 
     def getNbFrames(self):
@@ -977,30 +974,8 @@ class EdfImage(FabioImage):
         deleter for edf Data
         """
         self._frames[self.currentframe].data = None
+
     data = property(getData, setData, delData, "property: data of EDF file")
-
-    def getCapsHeader(self):
-        """
-        getter for edf headers keys in upper case
-        :return: data for current frame
-        :rtype: dict
-        """
-        return self._frames[self.currentframe].capsHeader
-
-    def setCapsHeader(self, _data):
-        """
-        Enforces the propagation of the header_keys to the list of frames
-        :param _data: numpy array representing data
-        """
-        self._frames[self.currentframe].capsHeader = _data
-
-    def delCapsHeader(self):
-        """
-        deleter for edf capsHeader
-        """
-        self._frames[self.currentframe].capsHeader = {}
-
-    capsHeader = property(getCapsHeader, setCapsHeader, delCapsHeader, "property: capsHeader of EDF file, i.e. the keys of the header in UPPER case.")
 
     def getDim1(self):
         return self._frames[self.currentframe].dim1

--- a/fabio/edfimage.py
+++ b/fabio/edfimage.py
@@ -249,11 +249,12 @@ class Frame(object):
         """
         Decide if we need to byteswap
         """
-        if ('Low' in self.header[self.capsHeader['BYTEORDER']] and numpy.little_endian) or \
-           ('High' in self.header[self.capsHeader['BYTEORDER']] and not numpy.little_endian):
+        byte_order = self.header[self.capsHeader['BYTEORDER']]
+        if ('Low' in byte_order and numpy.little_endian) or \
+           ('High' in byte_order and not numpy.little_endian):
             return False
-        if ('High' in self.header[self.capsHeader['BYTEORDER']] and numpy.little_endian) or \
-           ('Low' in self.header[self.capsHeader['BYTEORDER']] and not numpy.little_endian):
+        if ('High' in byte_order and numpy.little_endian) or \
+           ('Low' in byte_order and not numpy.little_endian):
             if self.bpp in [2, 4, 8]:
                 return True
             else:
@@ -708,14 +709,7 @@ class EdfImage(FabioImage):
 
         :return: True if needed, False else and None if not understood
         """
-        if self.bpp == 1:
-            return False
-        if ('Low' in self.header[self.capsHeader['BYTEORDER']] and numpy.little_endian) or \
-           ('High' in self.header[self.capsHeader['BYTEORDER']] and not numpy.little_endian):
-            return False
-        if ('High' in self.header[self.capsHeader['BYTEORDER']] and numpy.little_endian) or \
-           ('Low' in self.header[self.capsHeader['BYTEORDER']] and not numpy.little_endian):
-            return True
+        return self._frames[self.currentframe].swap_needed()
 
     def unpack(self):
         """
@@ -825,7 +819,7 @@ class EdfImage(FabioImage):
             data.shape = self.data.shape
         except Exception as error:
             logger.error("unable to convert file content to numpy array: %s", error)
-        if self.swap_needed():
+        if frame.swap_needed():
             data.byteswap(True)
         return data
 
@@ -865,7 +859,7 @@ class EdfImage(FabioImage):
             data.shape = -1, d1
         except Exception as error:
             logger.error("unable to convert file content to numpy array: %s", error)
-        if self.swap_needed():
+        if frame.swap_needed():
             data.byteswap(True)
         return data[slice2]
 

--- a/fabio/edfimage.py
+++ b/fabio/edfimage.py
@@ -147,6 +147,7 @@ class Frame(object):
         self.bpp = None
         self.incomplete_data = False
         self._bytecode = None
+
         if (number is not None):
             self.iFrame = int(number)
         else:
@@ -341,6 +342,7 @@ class Frame(object):
     def setData(self, npa=None):
         """Setter for data in edf frame"""
         self._data = npa
+
     data = property(getData, setData, "property: (edf)frame.data, uncompress the datablock when needed")
 
     def getByteCode(self):
@@ -378,7 +380,7 @@ class Frame(object):
         capsHeader = self.capsHeader.copy()
 
         listHeader = ["{\n"]
-#        First of all clean up the headers:
+        # First of all clean up the headers:
         for i in capsHeader:
             if "DIM_" in i:
                 header.pop(capsHeader[i])
@@ -394,7 +396,7 @@ class Frame(object):
                 header["EDF_DataBlockID"] = header.pop(capsHeader["EDF_DATABLOCKID"])
                 capsHeader["EDF_DATABLOCKID"] = "EDF_DataBlockID"
 
-#            Then update static headers freshly deleted
+        # Then update static headers freshly deleted
         header_keys.insert(0, "Size")
         header["Size"] = len(data.tostring())
         header_keys.insert(0, "HeaderID")
@@ -867,9 +869,10 @@ class EdfImage(FabioImage):
             data.byteswap(True)
         return data[slice2]
 
-################################################################################
-# Properties definition for header, data, header_keys and capsHeader
-################################################################################
+    ############################################################################
+    # Properties definition for header, data, header_keys and capsHeader
+    ############################################################################
+
     def getNbFrames(self):
         """
         Getter for number of frames
@@ -907,32 +910,8 @@ class EdfImage(FabioImage):
         Deleter for edf header
         """
         self._frames[self.currentframe].header = {}
-    header = property(getHeader, setHeader, delHeader, "property: header of EDF file")
 
-#     def getHeaderKeys(self):
-#         """
-#         Getter for edf header_keys
-#         """
-#         return self._frames[self.currentframe].header_keys
-#     def setHeaderKeys(self, _listtHeader):
-#         """
-#         Enforces the propagation of the header_keys to the list of frames
-#         :param _listtHeader: list of the (ordered) keys in the header
-#         :type _listtHeader: python list
-#         """
-#         try:
-#             self._frames[self.currentframe].header_keys = _listtHeader
-#         except AttributeError:
-#             self._frames = [Frame(header_keys=_listtHeader)]
-#         except IndexError:
-#             if self.currentframe < len(self._frames):
-#                 self._frames.append(Frame(header_keys=_listtHeader))
-#     def delHeaderKeys(self):
-#         """
-#         Deleter for edf header_keys
-#         """
-#         self._frames[self.currentframe].header_keys = []
-#     header_keys = property(getHeaderKeys, setHeaderKeys, delHeaderKeys, "property: header_keys of EDF file")
+    header = property(getHeader, setHeader, delHeader, "property: header of EDF file")
 
     def getData(self):
         """
@@ -992,6 +971,7 @@ class EdfImage(FabioImage):
         deleter for edf capsHeader
         """
         self._frames[self.currentframe].capsHeader = {}
+
     capsHeader = property(getCapsHeader, setCapsHeader, delCapsHeader, "property: capsHeader of EDF file, i.e. the keys of the header in UPPER case.")
 
     def getDim1(self):

--- a/fabio/edfimage.py
+++ b/fabio/edfimage.py
@@ -369,15 +369,15 @@ class Frame(object):
             data = self.data
         fit2dMode = bool(fit2dMode)
 
-        self.capsHeader.clear()
+        # Compute map from normalized upper key to original key in the header
+        capsHeader = {}
         for key in self.header:
-            KEY = key.upper()
-            if KEY not in self.capsHeader:
-                self.capsHeader[KEY] = key
+            upperkey = key.upper()
+            if upperkey not in capsHeader:
+                capsHeader[upperkey] = key
 
         header = self.header.copy()
         header_keys = list(self.header.keys())
-        capsHeader = self.capsHeader.copy()
 
         listHeader = ["{\n"]
         # First of all clean up the headers:

--- a/fabio/edfimage.py
+++ b/fabio/edfimage.py
@@ -108,13 +108,13 @@ NUMPY_EDF_DTYPE = {"int8": "SignedByte",
                    "float128": "QuadrupleValue",
                    }
 
-MINIMUM_KEYS = ['HEADERID',
-                'IMAGE',
-                'BYTEORDER',
-                'DATATYPE',
-                'DIM_1',
-                'DIM_2',
-                'SIZE']  # Size is thought to be essential for writing at least
+MINIMUM_KEYS = set(['HEADERID',
+                    'IMAGE',
+                    'BYTEORDER',
+                    'DATATYPE',
+                    'DIM_1',
+                    'DIM_2',
+                    'SIZE'])  # Size is thought to be essential for writing at least
 
 DEFAULT_VALUES = {}
 # I do not define default values as they will be calculated at write time
@@ -701,10 +701,8 @@ class EdfImage(FabioImage):
                 raise Exception(error)
 
         for i, frame in enumerate(self._frames):
-            missing = []
-            for item in MINIMUM_KEYS:
-                if item not in frame.capsHeader:
-                    missing.append(item)
+            capsKeys = set([k.upper() for k in frame.header.keys()])
+            missing = list(MINIMUM_KEYS - capsKeys)
             if len(missing) > 0:
                 logger.info("EDF file %s frame %i misses mandatory keys: %s ", self.filename, i, " ".join(missing))
         self.currentframe = 0

--- a/fabio/test/testedfimage.py
+++ b/fabio/test/testedfimage.py
@@ -368,6 +368,16 @@ class TestEdfRegression(unittest.TestCase):
 
         del obj
 
+    def test_remove_metadata_header(self):
+        filename = UtilsTest.getimage("face.edf.bz2")[0:-4]
+        output_filename = os.path.join(UtilsTest.tempdir, "test_remove_metadata_header.edf")
+
+        image = fabio.open(filename)
+        del image.header["Dim_1"]
+        image.write(output_filename)
+        image2 = fabio.open(output_filename)
+        self.assertEqual(image.dims, image2.dims)
+
 
 class TestBadFiles(unittest.TestCase):
 

--- a/fabio/test/testedfimage.py
+++ b/fabio/test/testedfimage.py
@@ -172,8 +172,8 @@ class TestEdfs(unittest.TestCase):
             obj = edfimage()
             try:
                 obj.read(os.path.join(self.im_dir, name))
-            except:
-                print("Cannot read image", name)
+            except Exception:
+                logger.error("Cannot read image %s", name)
                 raise
             self.assertAlmostEqual(mini, obj.getmin(), 2, "testedfs: %s getmin()" % name)
             self.assertAlmostEqual(maxi, obj.getmax(), 2, "testedfs: %s getmax" % name)


### PR DESCRIPTION
- Remove self.capsHeadcer
- Create and use it only locally when reading/writing EDF headers
- Remove the `capsHeader` API