### PR TITLE
Fix rst README for PyPI

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -98,9 +98,9 @@ There are also fileseries related methods (next(), previous(), ...) which return
 Other feature:
 
 * possibility for using on-the-fly external compression - i.e. if files are
-stored as something as .gz, .bz2 etc could decompress them, using an external
-compression mechanism (if available). This is present in fabian but requires
-that images are edfs.
+  stored as something as .gz, .bz2 etc could decompress them, using an external
+  compression mechanism (if available). This is present in fabian but requires
+  that images are edfs.
 
 
 Known file formats
@@ -121,7 +121,7 @@ Known file formats
 
   + CbfImage (implements a fast byte offset de/compression scheme in python/cython)
   + PilatusImage (fileformat derived from Tiff)
-  * EigerImage (derived from HDF5/NeXus format)
+  + EigerImage (derived from HDF5/NeXus format)
 
 * ESRF:
 

--- a/README.rst
+++ b/README.rst
@@ -165,6 +165,7 @@ Known file formats
 * Nonius -> now owned by Bruker
 
 * HDF5: generic format for stack of images
+
   + Hdf5Image
   + EigerImage
 


### PR DESCRIPTION
The [package page on PyPI](https://pypi.python.org/pypi/fabio) currently shows the raw rst markup, which looks especially ugly when it's not in a monospace font. When the rst is valid, it shows as nicely rendered HTML instead.

I used the [readme package](https://pypi.python.org/pypi/readme) to find the changes needed.