### PR TITLE
EDF multi-frame iterator

### DIFF
--- a/fabio/edfimage.py
+++ b/fabio/edfimage.py
@@ -1042,3 +1042,72 @@ class EdfImage(FabioImage):
 
 
 edfimage = EdfImage
+
+
+def edf_lazy_iterator(fname):
+    """Iterates over the frames of an EDF multi-frame file.
+
+    This function optimizes sequential access to multi-frame EDF files,
+    by avoiding to read the whole file at first in order to get the number
+    of frames and an index of frames for faster random access.
+
+    Usage:
+
+    >>> from fabio.edfimage import edf_lazy_iterator
+    >>> for frame in edf_lazy_iterator("multiframe.edf"):
+    ...     print('Header:', frame.header)
+    ...     print('Data:', frame.data)
+
+    :param str fname: File name of the EDF file to read
+    """
+    edf = EdfImage()
+    infile = edf._open(fname, 'rb')
+
+    index = 0
+
+    while True:
+        try:
+            block = EdfImage._readHeaderBlock(infile, index)
+        except MalformedHeaderError:
+            logger.debug("Backtrace", exc_info=True)
+            if index == 0:
+                infile.close()
+                raise IOError("Invalid first header")
+            break
+
+        if block is None:
+            # end of file
+            if index == 0:
+                infile.close()
+                raise IOError("Empty file")
+            break
+
+        frame = Frame(number=index)
+        size = frame.parseheader(block)
+        frame.file = infile
+        frame.start = infile.tell()
+        frame.size = size
+
+        try:
+            # read data
+            frame.getData()
+        except Exception as error:
+            if isinstance(infile, fabioutils.GzipFile):
+                if compression.is_incomplete_gz_block_exception(error):
+                    frame.incomplete_data = True
+                    break
+            logger.warning("infile is %s" % infile)
+            logger.warning("Position is %s" % infile.tell())
+            logger.warning("size is %s" % size)
+            logger.error("It seams this error occurs under windows when reading a (large-) file over network: %s ", error)
+            infile.close()
+            raise Exception(error)
+
+        capsKeys = set([k.upper() for k in frame.header.keys()])
+        missing = list(MINIMUM_KEYS - capsKeys)
+        if len(missing) > 0:
+            logger.info("EDF file %s frame %i misses mandatory keys: %s ", fname, index, " ".join(missing))
+        yield frame
+        index += 1
+
+    infile.close()

--- a/fabio/edfimage.py
+++ b/fabio/edfimage.py
@@ -1044,24 +1044,25 @@ class EdfImage(FabioImage):
 edfimage = EdfImage
 
 
-def edf_lazy_iterator(fname):
+def edf_lazy_iterator(filename):
     """Iterates over the frames of an EDF multi-frame file.
 
-    This function optimizes sequential access to multi-frame EDF files,
+    This function optimizes sequential access to multi-frame EDF files
     by avoiding to read the whole file at first in order to get the number
-    of frames and an index of frames for faster random access.
+    of frames and build an index of frames for faster random access.
 
     Usage:
 
     >>> from fabio.edfimage import edf_lazy_iterator
+
     >>> for frame in edf_lazy_iterator("multiframe.edf"):
     ...     print('Header:', frame.header)
     ...     print('Data:', frame.data)
 
-    :param str fname: File name of the EDF file to read
+    :param str filename: File name of the EDF file to read
     """
     edf = EdfImage()
-    infile = edf._open(fname, 'rb')
+    infile = edf._open(filename, 'rb')
 
     index = 0
 
@@ -1093,7 +1094,7 @@ def edf_lazy_iterator(fname):
             frame.getData()
         except Exception as error:
             if isinstance(infile, fabioutils.GzipFile):
-                if compression.is_incomplete_gz_block_exception(error):
+                if compression_module.is_incomplete_gz_block_exception(error):
                     frame.incomplete_data = True
                     break
             logger.warning("infile is %s" % infile)
@@ -1106,7 +1107,7 @@ def edf_lazy_iterator(fname):
         capsKeys = set([k.upper() for k in frame.header.keys()])
         missing = list(MINIMUM_KEYS - capsKeys)
         if len(missing) > 0:
-            logger.info("EDF file %s frame %i misses mandatory keys: %s ", fname, index, " ".join(missing))
+            logger.info("EDF file %s frame %i misses mandatory keys: %s ", filename, index, " ".join(missing))
         yield frame
         index += 1
 


### PR DESCRIPTION
This PR proposes to add a `fabio.edfimage.edf_lazy_iterator` function that returns an iterator over the frames of a single multi-frame EDF file.

The benefit is to avoid reading the whole file to get the number of frames and build the index before doing anything.