### PR TITLE
Merge EDF frame iterator

### DIFF
--- a/fabio/edfimage.py
+++ b/fabio/edfimage.py
@@ -914,6 +914,22 @@ class EdfImage(FabioImage):
     # Properties definition for header, data, header_keys
     ############################################################################
 
+    def _get_any_frame(self):
+        """Returns the current if available, else create and return a new empty
+        frame."""
+        try:
+            return self._frames[self.currentframe]
+        except AttributeError:
+            frame = EdfFrame()
+            self._frames = [frame]
+            return frame
+        except IndexError:
+            if self.currentframe < len(self._frames):
+                frame = EdfFrame()
+                self._frames.append(frame)
+                return frame
+            raise
+
     def getNbFrames(self):
         """
         Getter for number of frames
@@ -938,13 +954,8 @@ class EdfImage(FabioImage):
         """
         Enforces the propagation of the header to the list of frames
         """
-        try:
-            self._frames[self.currentframe].header = _dictHeader
-        except AttributeError:
-            self._frames = [EdfFrame(header=_dictHeader)]
-        except IndexError:
-            if self.currentframe < len(self._frames):
-                self._frames.append(EdfFrame(header=_dictHeader))
+        frame = self._get_any_frame()
+        frame.header = _dictHeader
 
     def delHeader(self):
         """
@@ -960,16 +971,8 @@ class EdfImage(FabioImage):
         :return: data for current frame
         :rtype: numpy.ndarray
         """
-        npaData = None
-        try:
-            npaData = self._frames[self.currentframe].data
-        except AttributeError:
-            self._frames = [EdfFrame()]
-            npaData = self._frames[self.currentframe].data
-        except IndexError:
-            if self.currentframe < len(self._frames):
-                self._frames.append(EdfFrame())
-                npaData = self._frames[self.currentframe].data
+        frame = self._get_any_frame()
+        npaData = frame.data
         return npaData
 
     def setData(self, data=None, _data=None):
@@ -980,13 +983,8 @@ class EdfImage(FabioImage):
         if _data is not None:
             fabioutils.deprecated_warning("Argument", "'_data'", replacement="argument 'data'", since_version=0.8)
             data = _data
-        try:
-            self._frames[self.currentframe].data = data
-        except AttributeError:
-            self._frames = [EdfFrame(data=_data)]
-        except IndexError:
-            if self.currentframe < len(self._frames):
-                self._frames.append(EdfFrame(data=_data))
+        frame = self._get_any_frame()
+        frame.data = data
 
     def delData(self):
         """
@@ -1003,14 +1001,8 @@ class EdfImage(FabioImage):
         if _iVal is not None:
             fabioutils.deprecated_warning("Argument", "'_iVal'", replacement="argument 'iVal'", since_version=0.8)
             iVal = _iVal
-        try:
-            self._frames[self.currentframe].dim1 = iVal
-        except AttributeError:
-            self._frames = [EdfFrame()]
-        except IndexError:
-            if self.currentframe < len(self._frames):
-                self._frames.append(EdfFrame())
-                self._frames[self.currentframe].dim1 = _iVal
+        frame = self._get_any_frame()
+        frame.dim1 = iVal
 
     dim1 = property(getDim1, setDim1)
 
@@ -1021,14 +1013,8 @@ class EdfImage(FabioImage):
         if _iVal is not None:
             fabioutils.deprecated_warning("Argument", "'_iVal'", replacement="argument 'iVal'", since_version=0.8)
             iVal = _iVal
-        try:
-            self._frames[self.currentframe].dim2 = iVal
-        except AttributeError:
-            self._frames = [EdfFrame()]
-        except IndexError:
-            if self.currentframe < len(self._frames):
-                self._frames.append(EdfFrame())
-                self._frames[self.currentframe].dim2 = iVal
+        frame = self._get_any_frame()
+        frame.dim2 = iVal
 
     dim2 = property(getDim2, setDim2)
 
@@ -1043,14 +1029,8 @@ class EdfImage(FabioImage):
         if _iVal is not None:
             fabioutils.deprecated_warning("Argument", "'_iVal'", replacement="argument 'iVal'", since_version=0.8)
             iVal = _iVal
-        try:
-            self._frames[self.currentframe].bytecode = iVal
-        except AttributeError:
-            self._frames = [EdfFrame()]
-        except IndexError:
-            if self.currentframe < len(self._frames):
-                self._frames.append(EdfFrame())
-                self._frames[self.currentframe].bytecode = iVal
+        frame = self._get_any_frame()
+        frame.bytecode = iVal
 
     bytecode = property(getByteCode, setByteCode)
 
@@ -1061,14 +1041,8 @@ class EdfImage(FabioImage):
         if _iVal is not None:
             fabioutils.deprecated_warning("Argument", "'_iVal'", replacement="argument 'iVal'", since_version=0.8)
             iVal = _iVal
-        try:
-            self._frames[self.currentframe].bpp = iVal
-        except AttributeError:
-            self._frames = [EdfFrame()]
-        except IndexError:
-            if self.currentframe < len(self._frames):
-                self._frames.append(EdfFrame())
-                self._frames[self.currentframe].bpp = iVal
+        frame = self._get_any_frame()
+        frame.bpp = iVal
 
     bpp = property(getBpp, setBpp)
 

--- a/fabio/edfimage.py
+++ b/fabio/edfimage.py
@@ -941,7 +941,8 @@ class EdfImage(FabioImage):
         Setter for number of frames ... should do nothing. Here just to avoid bugs
         """
         if val != len(self._frames):
-            logger.warning("trying to set the number of frames ")
+            logger.warning("Setting the number of frames is not allowed.")
+
     nframes = property(getNbFrames, setNbFrames, "property: number of frames in EDF file")
 
     def getHeader(self):

--- a/fabio/edfimage.py
+++ b/fabio/edfimage.py
@@ -972,13 +972,16 @@ class EdfImage(FabioImage):
                 npaData = self._frames[self.currentframe].data
         return npaData
 
-    def setData(self, _data):
+    def setData(self, data=None, _data=None):
         """
         Enforces the propagation of the data to the list of frames
-        :param _data: numpy array representing data
+        :param data: numpy array representing data
         """
+        if _data is not None:
+            fabioutils.deprecated_warning("Argument", "'_data'", replacement="argument 'data'", since_version=0.8)
+            data = _data
         try:
-            self._frames[self.currentframe].data = _data
+            self._frames[self.currentframe].data = data
         except AttributeError:
             self._frames = [EdfFrame(data=_data)]
         except IndexError:

--- a/fabio/edfimage.py
+++ b/fabio/edfimage.py
@@ -999,29 +999,37 @@ class EdfImage(FabioImage):
     def getDim1(self):
         return self._frames[self.currentframe].dim1
 
-    def setDim1(self, _iVal):
+    def setDim1(self, iVal=None, _iVal=None):
+        if _iVal is not None:
+            fabioutils.deprecated_warning("Argument", "'_iVal'", replacement="argument 'iVal'", since_version=0.8)
+            iVal = _iVal
         try:
-            self._frames[self.currentframe].dim1 = _iVal
+            self._frames[self.currentframe].dim1 = iVal
         except AttributeError:
             self._frames = [EdfFrame()]
         except IndexError:
             if self.currentframe < len(self._frames):
                 self._frames.append(EdfFrame())
                 self._frames[self.currentframe].dim1 = _iVal
+
     dim1 = property(getDim1, setDim1)
 
     def getDim2(self):
         return self._frames[self.currentframe].dim2
 
-    def setDim2(self, _iVal):
+    def setDim2(self, iVal=None, _iVal=None):
+        if _iVal is not None:
+            fabioutils.deprecated_warning("Argument", "'_iVal'", replacement="argument 'iVal'", since_version=0.8)
+            iVal = _iVal
         try:
-            self._frames[self.currentframe].dim2 = _iVal
+            self._frames[self.currentframe].dim2 = iVal
         except AttributeError:
             self._frames = [EdfFrame()]
         except IndexError:
             if self.currentframe < len(self._frames):
                 self._frames.append(EdfFrame())
-                self._frames[self.currentframe].dim2 = _iVal
+                self._frames[self.currentframe].dim2 = iVal
+
     dim2 = property(getDim2, setDim2)
 
     def getDims(self):
@@ -1031,29 +1039,37 @@ class EdfImage(FabioImage):
     def getByteCode(self):
         return self._frames[self.currentframe].bytecode
 
-    def setByteCode(self, _iVal):
+    def setByteCode(self, iVal=None, _iVal=None):
+        if _iVal is not None:
+            fabioutils.deprecated_warning("Argument", "'_iVal'", replacement="argument 'iVal'", since_version=0.8)
+            iVal = _iVal
         try:
-            self._frames[self.currentframe].bytecode = _iVal
+            self._frames[self.currentframe].bytecode = iVal
         except AttributeError:
             self._frames = [EdfFrame()]
         except IndexError:
             if self.currentframe < len(self._frames):
                 self._frames.append(EdfFrame())
-                self._frames[self.currentframe].bytecode = _iVal
+                self._frames[self.currentframe].bytecode = iVal
+
     bytecode = property(getByteCode, setByteCode)
 
     def getBpp(self):
         return self._frames[self.currentframe].bpp
 
-    def setBpp(self, _iVal):
+    def setBpp(self, iVal=None, _iVal=None):
+        if _iVal is not None:
+            fabioutils.deprecated_warning("Argument", "'_iVal'", replacement="argument 'iVal'", since_version=0.8)
+            iVal = _iVal
         try:
-            self._frames[self.currentframe].bpp = _iVal
+            self._frames[self.currentframe].bpp = iVal
         except AttributeError:
             self._frames = [EdfFrame()]
         except IndexError:
             if self.currentframe < len(self._frames):
                 self._frames.append(EdfFrame())
-                self._frames[self.currentframe].bpp = _iVal
+                self._frames[self.currentframe].bpp = iVal
+
     bpp = property(getBpp, setBpp)
 
     def isIncompleteData(self):

--- a/fabio/fabioimage.py
+++ b/fabio/fabioimage.py
@@ -44,7 +44,7 @@ __authors__ = ["Henning O. Sorensen", "Erik Knudsen", "Jon Wright", "Jérôme Ki
 __contact__ = "jerome.kieffer@esrf.fr"
 __license__ = "MIT"
 __copyright__ = "ESRF"
-__date__ = "22/10/2018"
+__date__ = "23/10/2018"
 
 import os
 import logging
@@ -99,9 +99,9 @@ class FabioImage(object):
         if type(data) in fabioutils.StringTypes:
             raise Exception("fabioimage.__init__ bad argument - " +
                             "data should be numpy array")
-        self.data = self.check_data(data)
+        self._data = self.check_data(data)
+        self._header = self.check_header(header)
         self.pilimage = None
-        self.header = self.check_header(header)
         # cache for image statistics
         self.mean = self.maxval = self.stddev = self.minval = None
         # Cache roi
@@ -109,7 +109,7 @@ class FabioImage(object):
         self.area_sum = None
         self.slice = None
         # New for multiframe files
-        self.nframes = 1
+        self._nframes = 1
         self.currentframe = 0
         self.filename = None
         self.filenumber = None
@@ -132,6 +132,30 @@ class FabioImage(object):
             logger.warning("Only copying current frame")
         other.filename = self.filename
         return other
+
+    def _get_data(self):
+        return self._data
+
+    def _set_data(self, data):
+        self._data = data
+
+    data = property(_get_data, _set_data)
+
+    def _get_header(self):
+        return self._header
+
+    def _set_header(self, header):
+        self._header = header
+
+    header = property(_get_header, _set_header)
+
+    def _get_nframes(self):
+        return self._nframes
+
+    def _set_nframes(self, nframes):
+        self._nframes = nframes
+
+    nframes = property(_get_nframes, _set_nframes)
 
     @property
     def incomplete_file(self):

--- a/fabio/fabioutils.py
+++ b/fabio/fabioutils.py
@@ -38,7 +38,7 @@ __author__ = "Jérôme Kieffer"
 __contact__ = "Jerome.Kieffer@ESRF.eu"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
-__date__ = "22/10/2018"
+__date__ = "23/10/2018"
 __status__ = "stable"
 __docformat__ = 'restructuredtext'
 
@@ -59,6 +59,8 @@ except ImportError:
         import pathlib2 as pathlib
     except ImportError:
         pathlib = None
+
+depreclog = logging.getLogger("fabio.DEPRECATION")
 
 if six.PY2:
     bytes_ = str
@@ -104,7 +106,7 @@ def deprecated(func):
             func_name = func.__name__
         else:
             func_name = func.func_name
-        logger.warning("%s is Deprecated !!! %s" % (func_name, os.linesep.join([""] + traceback.format_stack()[:-1])))
+        depreclog.warning("%s is deprecated !!! %s" % (func_name, os.linesep.join([""] + traceback.format_stack()[:-1])))
         return func(*arg, **kw)
     return wrapper
 

--- a/fabio/test/test_failing_files.py
+++ b/fabio/test/test_failing_files.py
@@ -88,10 +88,14 @@ class TestFailingFiles(unittest.TestCase):
         self.assertRaises(IOError, fabio.open, self.txt_filename)
 
     def test_wrong_edf(self):
-        self.assertRaises(IOError, fabio.open, self.bad_edf_filename)
+        with self.assertRaises(IOError):
+            image = fabio.open(self.bad_edf_filename)
+            image.data
 
     def test_wrong_edf2(self):
-        self.assertRaises(IOError, fabio.open, self.bad_edf_filename)
+        with self.assertRaises(IOError):
+            image = fabio.open(self.bad_edf2_filename)
+            image.data
 
     def test_wrong_msk(self):
         self.assertRaises(ValueError, fabio.open, self.bad_msk_filename)

--- a/fabio/test/testedfimage.py
+++ b/fabio/test/testedfimage.py
@@ -432,6 +432,8 @@ class TestBadFiles(unittest.TestCase):
     def open(cls, filename):
         image = fabio.edfimage.EdfImage()
         image.read(filename)
+        # force synchronization
+        image.data
         return image
 
     def test_base(self):
@@ -557,7 +559,7 @@ class TestBadGzFiles(TestBadFiles):
             TestBadFiles.write_data(gzfd)
 
 
-class TestEdfIterator(unittest.TestCase):
+class TestEdfLazyIterator(unittest.TestCase):
     """Read different EDF files with lazy iterator
     """
 
@@ -565,7 +567,7 @@ class TestEdfIterator(unittest.TestCase):
         """Test iterator on a multi-frame EDF"""
         filename = UtilsTest.getimage("MultiFrame.edf.bz2")
 
-        iterator = fabio.edfimage.EdfImage.lazy_iterator(filename)
+        iterator = fabio.open(filename).frames()
         ref = fabio.open(filename)
 
         for index in range(ref.nframes):
@@ -580,7 +582,7 @@ class TestEdfIterator(unittest.TestCase):
     def test_single_frame(self):
         """Test iterator on a single frame EDF"""
         filename = UtilsTest.getimage("edfCompressed_U16.edf")
-        iterator = fabio.edfimage.EdfImage.lazy_iterator(filename)
+        iterator = fabio.open(filename).frames()
 
         frame = next(iterator)
         ref = fabio.open(filename)
@@ -605,7 +607,7 @@ def suite():
     testsuite.addTest(loadTests(TestEdfRegression))
     testsuite.addTest(loadTests(TestBadFiles))
     testsuite.addTest(loadTests(TestBadGzFiles))
-    testsuite.addTest(loadTests(TestEdfIterator))
+    testsuite.addTest(loadTests(TestEdfLazyIterator))
     return testsuite
 
 


### PR DESCRIPTION
Here is a merge to provide a lazy loadable file image.

- It speed up reading big multi-frames
- But there is no more `IOError` execptions when the file object is created

Then it could be nice to:
- [ ] Create a `sync()` function to be sure everything was read.
- [ ] Or add a flag to the constructor to enable the feature
- [ ] Be able to call `nbframes` inside the `frames()` loop (it's tricky)

```
image = fabio.open("file.edf")
for frame in image.frames():
    pass
```

Closes #258