### PR TITLE
Small clean up

### DIFF
--- a/fabio/GEimage.py
+++ b/fabio/GEimage.py
@@ -38,11 +38,11 @@
 
 # modifications by Jon Wright for style, pychecker and fabio
 #
-# Get ready for python3:
+
 from __future__ import with_statement, print_function, division
 
 __authors__ = ["Antonino Miceli", "Jon Wright", "Jérôme Kieffer"]
-__date__ = "22/10/2018"
+__date__ = "29/10/2018"
 __status__ = "production"
 __copyright__ = "2007 APS; 2010-2015 ESRF"
 __licence__ = "MIT"

--- a/fabio/GEimage.py
+++ b/fabio/GEimage.py
@@ -332,35 +332,4 @@ class GeImage(FabioImage):
             return newobj
 
 
-def demo():
-    import sys
-    import time
-
-    if len(sys.argv) < 2:
-        print("USAGE: GE_script.py <GEaSi_raw_image_file>")
-        sys.exit()
-
-    image_file = sys.argv[1]
-
-    print("init read_GEaSi_data class and load header..")
-    sequence1 = GeImage()
-    sequence1.read(image_file)
-
-    print("TimeBetweenFramesInMicrosecs = ")
-    print(sequence1.header['TimeBetweenFramesInMicrosecs'])
-    print("AcquisitionTime = ")
-    print(sequence1.header['AcquisitionTime'])
-
-    print("Mean = ", sequence1.data.ravel().mean())
-
-    while 1:
-        start = time.time()
-        sequence1 = sequence1.next()
-        duration = time.time() - start
-        print(sequence1.currentframe, sequence1.data.ravel().mean(), duration)
-
-
 GEimage = GeImage
-
-if __name__ == '__main__':
-    demo()

--- a/fabio/HiPiCimage.py
+++ b/fabio/HiPiCimage.py
@@ -40,7 +40,6 @@ Authors: Henning O. Sorensen & Erik Knudsen
 Information about the file format from Masakatzu Kobayashi is highly appreciated
 """
 
-# Get ready for python3:
 from __future__ import with_statement, print_function
 
 import numpy

--- a/fabio/OXDimage.py
+++ b/fabio/OXDimage.py
@@ -42,13 +42,12 @@ Authors:
 
 """
 
-# Get ready for python3:
 from __future__ import with_statement, print_function
 
 __contact__ = "Jerome.Kieffer@esrf.fr"
 __license__ = "MIT"
 __copyright__ = "Jérôme Kieffer"
-__date__ = "25/06/2018"
+__date__ = "29/10/2018"
 
 import time
 import logging

--- a/fabio/TiffIO.py
+++ b/fabio/TiffIO.py
@@ -27,7 +27,7 @@ __author__ = "V.A. Sole - ESRF Data Analysis"
 __contact__ = "sole@esrf.fr"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
-__date__ = "22/10/2018"
+__date__ = "29/10/2018"
 
 import sys
 import os
@@ -1223,33 +1223,3 @@ class TiffIO(object):
             outputIFD += stripByteCountsString
 
         return outputIFD
-
-
-if __name__ == "__main__":
-    filename = sys.argv[1]
-    dtype = numpy.uint16
-    if not os.path.exists(filename):
-        print("Testing file creation")
-        tif = TiffIO(filename, mode='wb+')
-        data = numpy.arange(10000).astype(dtype)
-        data.shape = 100, 100
-        tif.writeImage(data, info={'Title': '1st'})
-        tif = None
-        if os.path.exists(filename):
-            print("Testing image appending")
-            tif = TiffIO(filename, mode='rb+')
-            tif.writeImage((data * 2).astype(dtype), info={'Title': '2nd'})
-            tif = None
-    tif = TiffIO(filename)
-    print("Number of images = %d" % tif.getNumberOfImages())
-    for i in range(tif.getNumberOfImages()):
-        info = tif.getInfo(i)
-        for key in info:
-            if key not in ["colormap"]:
-                print("%s = %s" % (key, info[key]))
-            elif info['colormap'] is not None:
-                print("RED   %s = %s" % (key, info[key][0:10, 0]))
-                print("GREEN %s = %s" % (key, info[key][0:10, 1]))
-                print("BLUE  %s = %s" % (key, info[key][0:10, 2]))
-        data = tif.getImage(i)[0, 0:10]
-        print("data [0, 0:10] = ", data)

--- a/fabio/adscimage.py
+++ b/fabio/adscimage.py
@@ -33,7 +33,7 @@ Authors: Henning O. Sorensen & Erik Knudsen
 + mods for fabio by JPW
 
 """
-# Get ready for python3:
+
 from __future__ import with_statement, print_function
 import numpy
 import logging

--- a/fabio/binaryimage.py
+++ b/fabio/binaryimage.py
@@ -34,7 +34,6 @@ data-type, dimensions, byte order and offset
 This simple library has been made for manipulating exotic/unknown files format.
 """
 
-# Get ready for python3:
 from __future__ import with_statement, print_function
 
 __authors__ = ["Gaël Goret", "Jérôme Kieffer", "Brian Pauw"]

--- a/fabio/edfimage.py
+++ b/fabio/edfimage.py
@@ -53,8 +53,8 @@ import string
 import logging
 logger = logging.getLogger(__name__)
 import numpy
-from .fabioimage import FabioImage, OrderedDict
-from .fabioutils import isAscii, toAscii, nice_int
+from .fabioimage import FabioImage
+from .fabioutils import isAscii, toAscii, nice_int, OrderedDict
 from .compression import decBzip2, decGzip, decZlib
 from . import compression as compression_module
 from . import fabioutils

--- a/fabio/edfimage.py
+++ b/fabio/edfimage.py
@@ -1128,4 +1128,6 @@ class EdfImage(FabioImage):
 
 
 Frame = EdfFrame
+"""Compatibility code with fabio <= 0.8"""
+
 edfimage = EdfImage

--- a/fabio/edfimage.py
+++ b/fabio/edfimage.py
@@ -127,7 +127,7 @@ class MalformedHeaderError(IOError):
     pass
 
 
-class Frame(object):
+class EdfFrame(object):
     """
     A class representing a single frame in an EDF file
     """
@@ -555,8 +555,8 @@ class EdfImage(FabioImage):
         FabioImage.__init__(self, stored_data, header)
 
         if frames is None:
-            frame = Frame(data=self.data, header=self.header,
-                          number=self.currentframe)
+            frame = EdfFrame(data=self.data, header=self.header,
+                             number=self.currentframe)
             self._frames = [frame]
         else:
             self._frames = frames
@@ -693,7 +693,7 @@ class EdfImage(FabioImage):
                     raise IOError("Empty file")
                 break
 
-            frame = Frame(number=self.nframes)
+            frame = EdfFrame(number=self.nframes)
             size = frame.parseheader(block)
             frame.file = infile
             frame.start = infile.tell()
@@ -830,12 +830,12 @@ class EdfImage(FabioImage):
         :param frame: frame to append to edf image
         :type frame: instance of Frame
         """
-        if isinstance(frame, Frame):
+        if isinstance(frame, EdfFrame):
             self._frames.append(frame)
         elif ("header" in dir(frame)) and ("data" in dir(frame)):
-            self._frames.append(Frame(frame.data, frame.header))
+            self._frames.append(EdfFrame(frame.data, frame.header))
         else:
-            self._frames.append(Frame(data, header))
+            self._frames.append(EdfFrame(data, header))
 
     def deleteFrame(self, frameNb=None):
         """
@@ -941,10 +941,10 @@ class EdfImage(FabioImage):
         try:
             self._frames[self.currentframe].header = _dictHeader
         except AttributeError:
-            self._frames = [Frame(header=_dictHeader)]
+            self._frames = [EdfFrame(header=_dictHeader)]
         except IndexError:
             if self.currentframe < len(self._frames):
-                self._frames.append(Frame(header=_dictHeader))
+                self._frames.append(EdfFrame(header=_dictHeader))
 
     def delHeader(self):
         """
@@ -964,11 +964,11 @@ class EdfImage(FabioImage):
         try:
             npaData = self._frames[self.currentframe].data
         except AttributeError:
-            self._frames = [Frame()]
+            self._frames = [EdfFrame()]
             npaData = self._frames[self.currentframe].data
         except IndexError:
             if self.currentframe < len(self._frames):
-                self._frames.append(Frame())
+                self._frames.append(EdfFrame())
                 npaData = self._frames[self.currentframe].data
         return npaData
 
@@ -980,10 +980,10 @@ class EdfImage(FabioImage):
         try:
             self._frames[self.currentframe].data = _data
         except AttributeError:
-            self._frames = [Frame(data=_data)]
+            self._frames = [EdfFrame(data=_data)]
         except IndexError:
             if self.currentframe < len(self._frames):
-                self._frames.append(Frame(data=_data))
+                self._frames.append(EdfFrame(data=_data))
 
     def delData(self):
         """
@@ -1000,10 +1000,10 @@ class EdfImage(FabioImage):
         try:
             self._frames[self.currentframe].dim1 = _iVal
         except AttributeError:
-            self._frames = [Frame()]
+            self._frames = [EdfFrame()]
         except IndexError:
             if self.currentframe < len(self._frames):
-                self._frames.append(Frame())
+                self._frames.append(EdfFrame())
                 self._frames[self.currentframe].dim1 = _iVal
     dim1 = property(getDim1, setDim1)
 
@@ -1014,10 +1014,10 @@ class EdfImage(FabioImage):
         try:
             self._frames[self.currentframe].dim2 = _iVal
         except AttributeError:
-            self._frames = [Frame()]
+            self._frames = [EdfFrame()]
         except IndexError:
             if self.currentframe < len(self._frames):
-                self._frames.append(Frame())
+                self._frames.append(EdfFrame())
                 self._frames[self.currentframe].dim2 = _iVal
     dim2 = property(getDim2, setDim2)
 
@@ -1032,10 +1032,10 @@ class EdfImage(FabioImage):
         try:
             self._frames[self.currentframe].bytecode = _iVal
         except AttributeError:
-            self._frames = [Frame()]
+            self._frames = [EdfFrame()]
         except IndexError:
             if self.currentframe < len(self._frames):
-                self._frames.append(Frame())
+                self._frames.append(EdfFrame())
                 self._frames[self.currentframe].bytecode = _iVal
     bytecode = property(getByteCode, setByteCode)
 
@@ -1046,10 +1046,10 @@ class EdfImage(FabioImage):
         try:
             self._frames[self.currentframe].bpp = _iVal
         except AttributeError:
-            self._frames = [Frame()]
+            self._frames = [EdfFrame()]
         except IndexError:
             if self.currentframe < len(self._frames):
-                self._frames.append(Frame())
+                self._frames.append(EdfFrame())
                 self._frames[self.currentframe].bpp = _iVal
     bpp = property(getBpp, setBpp)
 
@@ -1099,7 +1099,7 @@ class EdfImage(FabioImage):
                     raise IOError("Empty file")
                 break
 
-            frame = Frame(number=index)
+            frame = EdfFrame(number=index)
             size = frame.parseheader(block)
             frame.file = infile
             frame.start = infile.tell()
@@ -1127,4 +1127,5 @@ class EdfImage(FabioImage):
         infile.close()
 
 
+Frame = EdfFrame
 edfimage = EdfImage

--- a/fabio/eigerimage.py
+++ b/fabio/eigerimage.py
@@ -41,14 +41,14 @@ Under windows, those plugins can easily be installed via this repository:
 https://github.com/silx-kit/hdf5plugin
 
 """
-# Get ready for python3:
+
 from __future__ import with_statement, print_function, division
 
 __authors__ = ["Jérôme Kieffer"]
 __contact__ = "jerome.kieffer@esrf.fr"
 __license__ = "MIT"
 __copyright__ = "ESRF"
-__date__ = "25/07/2017"
+__date__ = "29/10/2018"
 
 import logging
 logger = logging.getLogger(__name__)

--- a/fabio/file_series.py
+++ b/fabio/file_series.py
@@ -42,9 +42,8 @@ Authors:
 * Jon Wright, ESRF
 
 """
-# Get ready for python3:
-from __future__ import absolute_import, print_function, with_statement, division
 
+from __future__ import absolute_import, print_function, with_statement, division
 
 import logging
 import sys

--- a/fabio/fit2dimage.py
+++ b/fabio/fit2dimage.py
@@ -29,14 +29,14 @@
 
 TODO: handle big-endian files
 """
-# Get ready for python3:
+
 from __future__ import with_statement, print_function, division
 
 __authors__ = ["Jérôme Kieffer"]
 __contact__ = "jerome.kiefer@esrf.fr"
 __license__ = "MIT"
 __copyright__ = "2016-2016 European Synchrotron Radiation Facility"
-__date__ = "25/06/2018"
+__date__ = "29/10/2018"
 
 import logging
 logger = logging.getLogger(__name__)

--- a/fabio/fit2dmaskimage.py
+++ b/fabio/fit2dmaskimage.py
@@ -32,7 +32,7 @@ Author: Andy Hammersley, ESRF
 Translation into python/fabio: Jon Wright, ESRF.
 Writer: Jérôme Kieffer
 """
-# Get ready for python3:
+
 from __future__ import with_statement, print_function
 
 __authors__ = ["Jon Wright", "Jérôme Kieffer"]

--- a/fabio/fit2dspreadsheetimage.py
+++ b/fabio/fit2dspreadsheetimage.py
@@ -32,7 +32,7 @@
 Read the fit2d ascii image output
         + Jon Wright, ESRF
 """
-# Get ready for python3:
+
 from __future__ import absolute_import, print_function, with_statement, division
 
 import numpy

--- a/fabio/hdf5image.py
+++ b/fabio/hdf5image.py
@@ -44,12 +44,11 @@ __authors__ = ["Jérôme Kieffer"]
 __contact__ = "Jerome.Kieffer@terre-adelie.org"
 __license__ = "MIT"
 __copyright__ = "Jérôme Kieffer"
-__date__ = "22/10/2018"
+__date__ = "29/10/2018"
 
 import logging
 import os
 import posixpath
-import sys
 from .fabioimage import FabioImage
 
 logger = logging.getLogger(__name__)

--- a/fabio/hdf5image.py
+++ b/fabio/hdf5image.py
@@ -60,6 +60,21 @@ except ImportError:
 from .fabioutils import previous_filename, next_filename
 
 
+class Hdf5Frame(object):
+    """Identify a slice of dataset from an HDF5 file"""
+
+    def __init__(self, hdf5image, frame_num):
+        if not isinstance(hdf5image, Hdf5Image):
+            raise TypeError("Expected class %s", Hdf5Image)
+        self.hdf5 = hdf5image.hdf5
+        self.dataset = hdf5image.dataset
+        self.filename = hdf5image.filename
+        self.nframes = hdf5image.nframes
+        self.data = hdf5image.dataset[frame_num, :, :]
+        self.header = hdf5image.header
+        self.currentframe = frame_num
+
+
 class Hdf5Image(FabioImage):
     """
     FabIO image class for Images from an HDF file
@@ -137,13 +152,7 @@ class Hdf5Image(FabioImage):
         if num < 0 or num > self.nframes:
             raise RuntimeError("Requested frame number %i is out of range [0, %i[ " % (num, self.nframes))
         # Do a deep copy of the header to make a new one
-        frame = self.__class__(header=self.header)
-        frame.hdf5 = self.hdf5
-        frame.dataset = self.dataset
-        frame.filename = self.filename
-        frame.nframes = self.nframes
-        frame.data = self.dataset[num, :, :]
-        frame.currentframe = num
+        frame = Hdf5Frame(self, num)
         return frame
 
     def next(self):

--- a/fabio/hdf5image.py
+++ b/fabio/hdf5image.py
@@ -37,7 +37,7 @@ filename::path
 
 Only supports ndim=2 or 3 (exposed as a stack of images
 """
-# Get ready for python3:
+
 from __future__ import with_statement, print_function, division
 
 __authors__ = ["Jérôme Kieffer"]

--- a/fabio/kcdimage.py
+++ b/fabio/kcdimage.py
@@ -33,7 +33,7 @@ Authors: Jerome Kieffer, ESRF
 kcd images are 2D images written by the old KappaCCD diffractometer built by Nonius in the 1990's
 Based on the edfimage.py parser.
 """
-# Get ready for python3:
+
 from __future__ import with_statement, print_function
 
 import numpy

--- a/fabio/mar345image.py
+++ b/fabio/mar345image.py
@@ -45,11 +45,11 @@ Supports Mar345 imaging plate and Mar555 flat panel
 Documentation on the format is available from:
 http://rayonix.com/site_media/downloads/mar345_formats.pdf
 """
-# Get ready for python3:
+
 from __future__ import with_statement, print_function, absolute_import
 
 __authors__ = ["Henning O. Sorensen", "Erik Knudsen", "Jon Wright", "Jérôme Kieffer"]
-__date__ = "22/10/2018"
+__date__ = "29/10/2018"
 __status__ = "production"
 __copyright__ = "2007-2009 Risoe National Laboratory; 2010-2016 ESRF"
 __licence__ = "MIT"

--- a/fabio/marccdimage.py
+++ b/fabio/marccdimage.py
@@ -45,7 +45,7 @@ marccdimage can read MarCCD and MarMosaic images including header info.
 JPW : Use a parser in case of typos (sorry?)
 
 """
-# Get ready for python3:
+
 from __future__ import with_statement, print_function, absolute_import
 
 # Base this on the tifimage (as marccd seems to be tiff with a

--- a/fabio/mpaimage.py
+++ b/fabio/mpaimage.py
@@ -35,7 +35,6 @@ Author:
 mpaimage can read ascii and binary .mpa (multiwire) files
 """
 
-# Get ready for python3:
 from __future__ import with_statement, print_function, division, absolute_import
 
 import logging

--- a/fabio/mrcimage.py
+++ b/fabio/mrcimage.py
@@ -33,7 +33,7 @@ email:  Jerome.Kieffer@terre-adelie.org
 Specifications from:
 http://ami.scripps.edu/software/mrctools/mrc_specification.php
 """
-# Get ready for python3:
+
 from __future__ import with_statement, print_function
 
 __authors__ = ["Jérôme Kieffer"]

--- a/fabio/numpyimage.py
+++ b/fabio/numpyimage.py
@@ -32,7 +32,7 @@ __authors__ = ["Jérôme Kieffer"]
 __contact__ = "jerome.kieffer@esrf.fr"
 __license__ = "MIT"
 __copyright__ = "ESRF"
-__date__ = "22/01/2018"
+__date__ = "29/10/2018"
 
 import logging
 logger = logging.getLogger(__name__)
@@ -173,18 +173,18 @@ class NumpyImage(FabioImage):
     def getframe(self, num):
         """ returns the frame numbered 'num' in the stack if applicable"""
         if self.nframes > 1:
-            new_img = None
+            frame = None
             if (num >= 0) and num < self.nframes:
                 data = self.dataset[num]
-                new_img = self.__class__(data=data, header=self.header)
-                new_img.dataset = self.dataset
-                new_img.nframes = self.nframes
-                new_img.currentframe = num
+                frame = self.__class__(data=data, header=self.header)
+                frame.dataset = self.dataset
+                frame.nframes = self.nframes
+                frame.currentframe = num
             else:
                 raise IndexError("getframe %s out of range [%s %s[" % (num, 0, self.nframes))
         else:
-            new_img = FabioImage.getframe(self, num)
-        return new_img
+            frame = FabioImage.getframe(self, num)
+        return frame
 
     def previous(self):
         """ returns the previous frame in the series as a fabioimage """

--- a/fabio/numpyimage.py
+++ b/fabio/numpyimage.py
@@ -25,7 +25,7 @@
 #
 
 """Generic numpy file reader for FabIO"""
-# Get ready for python3:
+
 from __future__ import with_statement, print_function, division
 
 __authors__ = ["Jérôme Kieffer"]

--- a/fabio/openimage.py
+++ b/fabio/openimage.py
@@ -39,7 +39,7 @@ mods for fabio by JPW
 modification for HDF5 by Jérôme Kieffer
 
 """
-# Get ready for python3:
+
 from __future__ import with_statement, print_function, absolute_import
 
 import os.path

--- a/fabio/pixiimage.py
+++ b/fabio/pixiimage.py
@@ -30,7 +30,7 @@
 """
 Author: Jon Wright, ESRF.
 """
-# Get ready for python3:
+
 from __future__ import with_statement, print_function
 
 __authors__ = ["Jon Wright", "Jérôme Kieffer"]

--- a/fabio/pixiimage.py
+++ b/fabio/pixiimage.py
@@ -37,7 +37,7 @@ __authors__ = ["Jon Wright", "Jérôme Kieffer"]
 __contact__ = "wright@esrf.fr"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
-__date__ = "25/06/2018"
+__date__ = "29/10/2018"
 
 import numpy
 import os
@@ -114,7 +114,7 @@ class PixiImage(FabioImage):
         newheader = {}
         for k in self.header.keys():
             newheader[k] = self.header[k]
-        frame = pixiimage(header=newheader)
+        frame = PixiImage(header=newheader)
         frame.nframes = self.nframes
         frame.sequencefilename = self.sequencefilename
         infile = frame._open(self.sequencefilename, "rb")
@@ -129,7 +129,7 @@ class PixiImage(FabioImage):
         if self.currentframe < (self.nframes - 1) and self.nframes > 1:
             return self.getframe(self.currentframe + 1)
         else:
-            newobj = pixiimage()
+            newobj = PixiImage()
             newobj.read(next_filename(
                 self.sequencefilename))
             return newobj
@@ -141,7 +141,7 @@ class PixiImage(FabioImage):
         if self.currentframe > 0:
             return self.getframe(self.currentframe - 1)
         else:
-            newobj = pixiimage()
+            newobj = PixiImage()
             newobj.read(previous_filename(
                 self.sequencefilename))
             return newobj

--- a/fabio/pixiimage.py
+++ b/fabio/pixiimage.py
@@ -28,6 +28,9 @@
 
 
 """
+File format to read images from PiXIrad PCDs manufactured by Pixirad Imaging
+Counters SRL (http://www.pixirad.com/)
+
 Author: Jon Wright, ESRF.
 """
 
@@ -148,24 +151,3 @@ class PixiImage(FabioImage):
 
 
 pixiimage = PixiImage
-
-
-def demo(fname):
-    i = PixiImage()
-    i.read(fname)
-    import pylab
-    pylab.imshow(numpy.log(i.data))
-    print("%s\t%s\t%s\t%s" % (i.filename, i.data.max(), i.data.min(), i.data.mean()))
-    pylab.title(i.filename)
-    pylab.show()
-    while 1:
-        i = i.next()
-        pylab.imshow(numpy.log(i.data))
-        pylab.title(i.filename)
-        pylab.show()
-        raw_input()
-
-
-if __name__ == "__main__":
-    import sys
-    demo(sys.argv[1])

--- a/fabio/pixiimage.py
+++ b/fabio/pixiimage.py
@@ -72,7 +72,7 @@ class PixiImage(FabioImage):
             self.header['height'] = height
             self.header['offset'] = offset
         else:
-            logger.warning("Pixiimage, bad framesize: %s", framesize)
+            logger.warning("Bad framesize: %s", framesize)
             raise
 
     def read(self, fname, frame=None):

--- a/fabio/pixiimage.py
+++ b/fabio/pixiimage.py
@@ -82,7 +82,7 @@ class PixiImage(FabioImage):
             self.header['offset'] = self._HEADER_SIZE
         else:
             logger.warning("Bad framesize: %s", framesize)
-            raise
+            raise Exception("Bad framesize")
 
     def read(self, fname, frame=None):
         if frame is None:

--- a/fabio/pnmimage.py
+++ b/fabio/pnmimage.py
@@ -41,10 +41,11 @@ Authors: Henning O. Sorensen & Erik Knudsen
 
 License: MIT
 """
-# Get ready for python3:
+
 from __future__ import absolute_import, print_function, with_statement, division
+
 __authors__ = ["Jérôme Kieffer", "Henning O. Sorensen", "Erik Knudsen"]
-__date__ = "25/06/2018"
+__date__ = "29/10/2018"
 __license__ = "MIT+"
 __copyright__ = "ESRF, Grenoble & Risoe National Laboratory"
 __status__ = "stable"

--- a/fabio/raxisimage.py
+++ b/fabio/raxisimage.py
@@ -35,15 +35,13 @@ Available at: http://www.rigaku.com/downloads/software/readimage.html
 
 """
 
-
-# Get ready for python3:
 from __future__ import with_statement, print_function, division
 
 __authors__ = ["Brian R. Pauw"]
 __contact__ = "brian@stack.nl"
 __license__ = "MIT"
 __copyright__ = "Brian R. Pauw"
-__date__ = "25/06/2018"
+__date__ = "29/10/2018"
 
 import logging
 import struct

--- a/fabio/readbytestream.py
+++ b/fabio/readbytestream.py
@@ -31,7 +31,7 @@
 Authors: Jon Wright    Henning O. Sorensen & Erik Knudsen
          ESRF          Risoe National Laboratory
 """
-# Get ready for python3:
+
 from __future__ import with_statement, print_function, division
 
 import logging

--- a/fabio/speimage.py
+++ b/fabio/speimage.py
@@ -32,14 +32,14 @@
 
 
 """
-# Get ready for python3:
+
 from __future__ import with_statement, print_function, division
 
 __authors__ = ["Clemens Prescher"]
 __contact__ = "c.prescher@uni-koeln.de"
 __license__ = "MIT"
 __copyright__ = "Clemens Prescher"
-__date__ = "24/07/2017"
+__date__ = "29/10/2018"
 
 import logging
 

--- a/fabio/templateimage.py
+++ b/fabio/templateimage.py
@@ -68,14 +68,14 @@ The basic idea is the following:
    don't need to convert their data into another format
 
 """
-# Get ready for python3:
+
 from __future__ import with_statement, print_function, division
 
 __authors__ = ["author"]
 __contact__ = "name@institut.org"
 __license__ = "MIT"
 __copyright__ = "Institut"
-__date__ = "22/08/2017"
+__date__ = "29/10/2018"
 
 import logging
 logger = logging.getLogger(__name__)

--- a/fabio/test/test_all.py
+++ b/fabio/test/test_all.py
@@ -72,6 +72,7 @@ from . import test_formats
 from . import test_image_convert
 from . import testmrcimage
 from . import test_pixi_image
+from . import test_tiffio
 
 
 def suite():
@@ -117,6 +118,7 @@ def suite():
     testSuite.addTest(test_image_convert.suite())
     testSuite.addTest(testmrcimage.suite())
     testSuite.addTest(test_pixi_image.suite())
+    testSuite.addTest(test_tiffio.suite())
     return testSuite
 
 

--- a/fabio/test/test_all.py
+++ b/fabio/test/test_all.py
@@ -71,6 +71,7 @@ from . import test_failing_files
 from . import test_formats
 from . import test_image_convert
 from . import testmrcimage
+from . import test_pixi_image
 
 
 def suite():
@@ -115,6 +116,7 @@ def suite():
     testSuite.addTest(test_formats.suite())
     testSuite.addTest(test_image_convert.suite())
     testSuite.addTest(testmrcimage.suite())
+    testSuite.addTest(test_pixi_image.suite())
     return testSuite
 
 

--- a/fabio/test/test_pixi_image.py
+++ b/fabio/test/test_pixi_image.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+#    Project: Fable Input Output
+#             https://github.com/silx-kit/fabio
+#
+#    Copyright (C) European Synchrotron Radiation Facility, Grenoble, France
+#
+#    Principal author:       Jérôme Kieffer (Jerome.Kieffer@ESRF.eu)
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+"""
+Deep test to check IOError exceptions
+"""
+
+from __future__ import print_function, with_statement, division, absolute_import
+
+import unittest
+import os
+import logging
+
+logger = logging.getLogger(__name__)
+
+import fabio
+from .utilstest import UtilsTest
+
+
+class TestPixiImage(unittest.TestCase):
+    """Test the class format"""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.create_fake_images()
+
+    @classmethod
+    def create_fake_images(cls):
+        """Create PiXi image.
+
+        This images was generated using our Python code as specification.
+        Then it's not a very good way to test our code.
+
+        FIXME: It would be good to find real images
+        """
+        frame1 = b"\x01\x00" * 476 + b"\x00\x00" * 476 * 511
+        frame2 = b"\x02\x00" * 476 + b"\x00\x00" * 476 * 511
+        frame3 = b"\x03\x00" * 476 + b"\x00\x00" * 476 * 511
+        header = b"\n\xb8\x03\x00" + b"\x00" * 20
+
+        cls.single_frame = os.path.join(UtilsTest.tempdir, "pixi_1frame.fake")
+        with open(cls.single_frame, 'wb') as f:
+            f.write(header)
+            f.write(frame1)
+
+        cls.multi_frame = os.path.join(UtilsTest.tempdir, "pixi_3frame.fake")
+        with open(cls.multi_frame, 'wb') as f:
+            f.write(header)
+            f.write(frame1)
+            f.write(header)
+            f.write(frame2)
+            f.write(header)
+            f.write(frame3)
+
+    def test_single_frame(self):
+        image = fabio.open(self.single_frame)
+        self.assertEqual(image.nframes, 1)
+        self.assertEqual(image.data.shape, (512, 476))
+        self.assertEqual(image.data[0, 0], 1)
+        self.assertEqual(image.data[1, 1], 0)
+
+    def test_multi_frame(self):
+        image = fabio.open(self.multi_frame)
+        self.assertEqual(image.nframes, 3)
+        self.assertEqual(image.data.shape, (512, 476))
+        self.assertEqual(image.data[0, 0], 1)
+        self.assertEqual(image.data[1, 1], 0)
+        frame = image.getframe(0)
+        self.assertEqual(frame.data[0, 0], 1)
+        self.assertEqual(frame.data[1, 1], 0)
+        frame = image.getframe(1)
+        self.assertEqual(frame.data[0, 0], 2)
+        self.assertEqual(frame.data[1, 1], 0)
+        frame = image.getframe(2)
+        self.assertEqual(frame.data[0, 0], 3)
+        self.assertEqual(frame.data[1, 1], 0)
+
+
+def suite():
+    loader = unittest.defaultTestLoader.loadTestsFromTestCase
+    testsuite = unittest.TestSuite()
+    testsuite.addTest(loader(TestPixiImage))
+    return testsuite
+
+
+if __name__ == '__main__':
+    runner = unittest.TextTestRunner()
+    runner.run(suite())

--- a/fabio/test/test_tiffio.py
+++ b/fabio/test/test_tiffio.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+#    Project: Fable Input Output
+#             https://github.com/silx-kit/fabio
+#
+#    Copyright (C) European Synchrotron Radiation Facility, Grenoble, France
+#
+#    Principal author:       Jérôme Kieffer (Jerome.Kieffer@ESRF.eu)
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+"""
+Test to check TiffIO
+"""
+
+from __future__ import print_function, with_statement, division, absolute_import
+
+import unittest
+import os
+import logging
+import numpy
+
+logger = logging.getLogger(__name__)
+
+from .utilstest import UtilsTest
+from ..TiffIO import TiffIO
+
+
+class TestTiffIO(unittest.TestCase):
+    """Test the class format"""
+
+    def write(self, filename):
+        tif = TiffIO(filename, mode='wb+')
+        dtype = numpy.uint16
+        data = numpy.arange(10000).astype(dtype)
+        data.shape = 100, 100
+        tif.writeImage(data, info={'Title': '1st'})
+        tif = None
+
+    def test_write(self):
+        filename = "%s.tiff" % self.id()
+        filename = os.path.join(UtilsTest.tempdir, filename)
+        self.write(filename)
+
+    def test_append(self):
+        filename = "%s.tiff" % self.id()
+        filename = os.path.join(UtilsTest.tempdir, filename)
+        self.write(filename)
+        # append
+        tif = TiffIO(filename, mode='rb+')
+        dtype = numpy.uint16
+        data = numpy.arange(100).astype(dtype)
+        data.shape = 10, 10
+        tif.writeImage((data * 2).astype(dtype), info={'Title': '2nd'})
+        self.assertEqual(tif.getNumberOfImages(), 2)
+        tif = None
+
+    def test_read(self):
+        filename = "%s.tiff" % self.id()
+        filename = os.path.join(UtilsTest.tempdir, filename)
+        self.write(filename)
+
+        tif = TiffIO(filename)
+        self.assertEqual(tif.getNumberOfImages(), 1)
+        for i in range(tif.getNumberOfImages()):
+            info = tif.getInfo(i)
+            for key in info:
+                if key not in ["colormap"]:
+                    logger.info("%s = %s", key, info[key])
+                elif info['colormap'] is not None:
+                    logger.info("RED   %s = %s", key, info[key][0:10, 0])
+                    logger.info("GREEN %s = %s", key, info[key][0:10, 1])
+                    logger.info("BLUE  %s = %s", key, info[key][0:10, 2])
+            data = tif.getImage(i)[0, 0:10]
+            logger.info("data [0, 0:10] = %s", data)
+
+
+def suite():
+    loader = unittest.defaultTestLoader.loadTestsFromTestCase
+    testsuite = unittest.TestSuite()
+    testsuite.addTest(loader(TestTiffIO))
+    return testsuite
+
+
+if __name__ == '__main__':
+    runner = unittest.TextTestRunner()
+    runner.run(suite())

--- a/fabio/test/testcompression.py
+++ b/fabio/test/testcompression.py
@@ -28,15 +28,13 @@
 #  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 #  OTHER DEALINGS IN THE SOFTWARE.
 
-#
-# Get ready for python3:
 from __future__ import with_statement, print_function, division
 
 __authors__ = ["Jérôme Kieffer"]
 __contact__ = "Jerome.Kieffer@esrf.fr"
 __license__ = "MIT"
 __copyright__ = "2011-2016 ESRF"
-__date__ = "22/10/2018"
+__date__ = "29/10/2018"
 
 import unittest
 import numpy

--- a/fabio/test/testfit2dimage.py
+++ b/fabio/test/testfit2dimage.py
@@ -26,14 +26,14 @@
 
 """Test for FabIO reader for Fit2D binary images
 """
-# Get ready for python3:
+
 from __future__ import with_statement, print_function, division, absolute_import
 
 __authors__ = ["Jérôme Kieffer"]
 __contact__ = "jerome.kiefer@esrf.fr"
 __license__ = "MIT"
 __copyright__ = "2016-2016 European Synchrotron Radiation Facility"
-__date__ = "22/10/2018"
+__date__ = "29/10/2018"
 
 import unittest
 import numpy

--- a/fabio/test/testspeimage.py
+++ b/fabio/test/testspeimage.py
@@ -28,15 +28,13 @@
 #  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 #  OTHER DEALINGS IN THE SOFTWARE.
 
-#
-# Get ready for python3:
 from __future__ import with_statement, print_function, division
 
 __authors__ = ["Clemens Prescher"]
 __contact__ = "c.prescher@uni-koeln.de"
 __license__ = "MIT"
 __copyright__ = "Clemens Prescher/Univeristy Köln, Germany"
-__date__ = "22/10/2018"
+__date__ = "29/10/2018"
 
 import unittest
 import numpy

--- a/fabio/tifimage.py
+++ b/fabio/tifimage.py
@@ -39,14 +39,12 @@ Authors:
 * Jérôme Kieffer:
   European Synchrotron Radiation Facility;
   Grenoble (France)
-
-License: MIT
 """
-# Get ready for python3:
+
 from __future__ import with_statement, print_function, division
 
 __authors__ = ["Jérôme Kieffer", "Henning O. Sorensen", "Erik Knudsen"]
-__date__ = "22/10/2018"
+__date__ = "29/10/2018"
 __license__ = "MIT"
 __copyright__ = "ESRF, Grenoble & Risoe National Laboratory"
 __status__ = "stable"

--- a/fabio/xsdimage.py
+++ b/fabio/xsdimage.py
@@ -30,8 +30,9 @@ Authors: Jérôme Kieffer, ESRF
 
 XSDimge are XML files containing numpy arrays
 """
-# Get ready for python3:
+
 from __future__ import absolute_import, print_function, with_statement, division
+
 __author__ = "Jérôme Kieffer"
 __contact__ = "jerome.kieffer@esrf.eu"
 __license__ = "MIT"


### PR DESCRIPTION
- Typo to prepare a shared class for frames
- Test PiXi format
- Clean up PiXi module
- Test TiffIO module
- Remove useless comments
- Remove `__name__ == "main"`
- `Hdf5Image` now returns an `Hdf5Frame` instead of an `Hdf5Image` (it could be a regression in case people uses `isinstance(f, Hdf5Image)`. I don't think it is a blocking patch)