### PR TITLE
Deprecation for 0.10.0

### DIFF
--- a/fabio/edfimage.py
+++ b/fabio/edfimage.py
@@ -1064,16 +1064,13 @@ class EdfImage(fabioimage.FabioImage):
         return self.data
 
     @deprecation.deprecated(reason="Prefer using 'img.data ='")
-    def setData(self, data=None, _data=None):
+    def setData(self, _data=None):
         """
         Enforces the propagation of the data to the list of frames
         :param data: numpy array representing data
         """
-        if _data is not None:
-            deprecation.deprecated_warning("Argument", "'_data'", replacement="argument 'data'", since_version=0.8)
-            data = _data
         frame = self._get_any_frame()
-        frame.data = data
+        frame.data = _data
 
     @deprecation.deprecated(reason="Prefer using 'del img.data'")
     def delData(self):
@@ -1087,12 +1084,9 @@ class EdfImage(fabioimage.FabioImage):
         return self.dim1
 
     @deprecation.deprecated(reason="Setting dim1 is not anymore allowed. If the data is not set use shape instead.")
-    def setDim1(self, iVal=None, _iVal=None):
-        if _iVal is not None:
-            deprecation.deprecated_warning("Argument", "'_iVal'", replacement="argument 'iVal'", since_version=0.8)
-            iVal = _iVal
+    def setDim1(self, _iVal=None):
         frame = self._get_any_frame()
-        frame.dim1 = iVal
+        frame.dim1 = _iVal
 
     @property
     def dim1(self):
@@ -1103,12 +1097,9 @@ class EdfImage(fabioimage.FabioImage):
         return self._frames[self.currentframe].dim2
 
     @deprecation.deprecated(reason="Setting dim2 is not anymore allowed. If the data is not set use shape instead.")
-    def setDim2(self, iVal=None, _iVal=None):
-        if _iVal is not None:
-            deprecation.deprecated_warning("Argument", "'_iVal'", replacement="argument 'iVal'", since_version=0.8)
-            iVal = _iVal
+    def setDim2(self, _iVal=None):
         frame = self._get_any_frame()
-        frame.dim2 = iVal
+        frame.dim2 = _iVal
 
     @property
     def dim2(self):

--- a/fabio/edfimage.py
+++ b/fabio/edfimage.py
@@ -406,7 +406,7 @@ class EdfFrame(fabioimage.FabioFrame):
         """Setter for data in edf frame"""
         self._data = value
 
-    @deprecation.deprecated(reason="Prefer using 'frame.data'")
+    @deprecation.deprecated(reason="Prefer using 'frame.data'", deprecated_since="0.10.0beta")
     def getData(self):
         """
         Returns the data after unpacking it if needed.
@@ -415,7 +415,7 @@ class EdfFrame(fabioimage.FabioFrame):
         """
         return self.data
 
-    @deprecation.deprecated(reason="Prefer using 'frame.data ='")
+    @deprecation.deprecated(reason="Prefer using 'frame.data ='", deprecated_since="0.10.0beta")
     def setData(self, npa=None):
         """Setter for data in edf frame"""
         self._data = npa
@@ -526,7 +526,7 @@ class EdfFrame(fabioimage.FabioFrame):
         listHeader.append(" " * (headerSize - preciseSize) + "}\n")
         return ("".join(listHeader)).encode("ASCII") + data.tostring()
 
-    @deprecation.deprecated(reason="Prefer using 'getEdfBlock'")
+    @deprecation.deprecated(reason="Prefer using 'getEdfBlock'", deprecated_since="0.10.0beta")
     def getEdfBlock(self, force_type=None, fit2dMode=False):
         return self.get_edf_block(force_type, fit2dMode)
 
@@ -860,7 +860,7 @@ class EdfImage(fabioimage.FabioImage):
         else:
             self._frames.append(EdfFrame(data, header))
 
-    @deprecation.deprecated(reason="Prefer using 'append_frame'")
+    @deprecation.deprecated(reason="Prefer using 'append_frame'", deprecated_since="0.10.0beta")
     def appendFrame(self, frame=None, data=None, header=None):
         self.append_frame(frame, data, header)
 
@@ -874,7 +874,7 @@ class EdfImage(fabioimage.FabioImage):
         else:
             self._frames.pop(frameNb)
 
-    @deprecation.deprecated(reason="Prefer using 'delete_frame'")
+    @deprecation.deprecated(reason="Prefer using 'delete_frame'", deprecated_since="0.10.0beta")
     def deleteFrame(self, frameNb=None):
         self.delete_frame(frameNb)
 
@@ -901,7 +901,7 @@ class EdfImage(fabioimage.FabioImage):
             data.byteswap(True)
         return data
 
-    @deprecation.deprecated(reason="Prefer using 'fastReadData'")
+    @deprecation.deprecated(reason="Prefer using 'fastReadData'", deprecated_since="0.10.0beta")
     def fastReadData(self, filename):
         return self.fast_read_data(filename)
 
@@ -945,7 +945,7 @@ class EdfImage(fabioimage.FabioImage):
             data.byteswap(True)
         return data[slice2]
 
-    @deprecation.deprecated(reason="Prefer using 'fast_read_roi'")
+    @deprecation.deprecated(reason="Prefer using 'fast_read_roi'", deprecated_since="0.10.0beta")
     def fastReadROI(self, filename, coords=None):
         return self.fast_read_roi(filename, coords)
 
@@ -977,14 +977,14 @@ class EdfImage(fabioimage.FabioImage):
         """
         return len(self._frames)
 
-    @deprecation.deprecated(reason="Prefer using 'img.nframes'")
+    @deprecation.deprecated(reason="Prefer using 'img.nframes'", deprecated_since="0.10.0beta")
     def getNbFrames(self):
         """
         Getter for number of frames
         """
         return len(self._frames)
 
-    @deprecation.deprecated(reason="This call to 'setNbFrames' does nothing and should be removed")
+    @deprecation.deprecated(reason="This call to 'setNbFrames' does nothing and should be removed", deprecated_since="0.10.0beta")
     def setNbFrames(self, val):
         """
         Setter for number of frames ... should do nothing. Here just to avoid bugs
@@ -1007,14 +1007,14 @@ class EdfImage(fabioimage.FabioImage):
         frame = self._get_any_frame()
         frame.header = None
 
-    @deprecation.deprecated(reason="Prefer using 'img.header'")
+    @deprecation.deprecated(reason="Prefer using 'img.header'", deprecated_since="0.10.0beta")
     def getHeader(self):
         """
         Getter for the headers. used by the property header,
         """
         return self._frames[self.currentframe].header
 
-    @deprecation.deprecated(reason="Prefer using 'img.header ='")
+    @deprecation.deprecated(reason="Prefer using 'img.header ='", deprecated_since="0.10.0beta")
     def setHeader(self, _dictHeader):
         """
         Enforces the propagation of the header to the list of frames
@@ -1022,7 +1022,7 @@ class EdfImage(fabioimage.FabioImage):
         frame = self._get_any_frame()
         frame.header = _dictHeader
 
-    @deprecation.deprecated(reason="Prefer using 'del img.header'")
+    @deprecation.deprecated(reason="Prefer using 'del img.header'", deprecated_since="0.10.0beta")
     def delHeader(self):
         """
         Deleter for edf header
@@ -1054,7 +1054,7 @@ class EdfImage(fabioimage.FabioImage):
         frame = self._get_any_frame()
         frame.data = None
 
-    @deprecation.deprecated(reason="Prefer using 'img.data'")
+    @deprecation.deprecated(reason="Prefer using 'img.data'", deprecated_since="0.10.0beta")
     def getData(self):
         """
         getter for edf Data
@@ -1063,7 +1063,7 @@ class EdfImage(fabioimage.FabioImage):
         """
         return self.data
 
-    @deprecation.deprecated(reason="Prefer using 'img.data ='")
+    @deprecation.deprecated(reason="Prefer using 'img.data ='", deprecated_since="0.10.0beta")
     def setData(self, _data=None):
         """
         Enforces the propagation of the data to the list of frames
@@ -1072,18 +1072,18 @@ class EdfImage(fabioimage.FabioImage):
         frame = self._get_any_frame()
         frame.data = _data
 
-    @deprecation.deprecated(reason="Prefer using 'del img.data'")
+    @deprecation.deprecated(reason="Prefer using 'del img.data'", deprecated_since="0.10.0beta")
     def delData(self):
         """
         deleter for edf Data
         """
         self._frames[self.currentframe].data = None
 
-    @deprecation.deprecated(reason="Prefer using 'dim1'")
+    @deprecation.deprecated(reason="Prefer using 'dim1'", deprecated_since="0.10.0beta")
     def getDim1(self):
         return self.dim1
 
-    @deprecation.deprecated(reason="Setting dim1 is not anymore allowed. If the data is not set use shape instead.")
+    @deprecation.deprecated(reason="Setting dim1 is not anymore allowed. If the data is not set use shape instead.", deprecated_since="0.10.0beta")
     def setDim1(self, _iVal=None):
         frame = self._get_any_frame()
         frame.dim1 = _iVal
@@ -1092,11 +1092,11 @@ class EdfImage(fabioimage.FabioImage):
     def dim1(self):
         return self._frames[self.currentframe].dim1
 
-    @deprecation.deprecated(reason="Prefer using 'dim2'")
+    @deprecation.deprecated(reason="Prefer using 'dim2'", deprecated_since="0.10.0beta")
     def getDim2(self):
         return self._frames[self.currentframe].dim2
 
-    @deprecation.deprecated(reason="Setting dim2 is not anymore allowed. If the data is not set use shape instead.")
+    @deprecation.deprecated(reason="Setting dim2 is not anymore allowed. If the data is not set use shape instead.", deprecated_since="0.10.0beta")
     def setDim2(self, _iVal=None):
         frame = self._get_any_frame()
         frame.dim2 = _iVal
@@ -1105,7 +1105,7 @@ class EdfImage(fabioimage.FabioImage):
     def dim2(self):
         return self._frames[self.currentframe].dim2
 
-    @deprecation.deprecated(reason="Prefer using 'dims'")
+    @deprecation.deprecated(reason="Prefer using 'dims'", deprecated_since="0.10.0beta")
     def getDims(self):
         return self._frames[self.currentframe].dims
 
@@ -1113,11 +1113,11 @@ class EdfImage(fabioimage.FabioImage):
     def dims(self):
         return self._frames[self.currentframe].dims
 
-    @deprecation.deprecated(reason="Prefer using 'bytecode'")
+    @deprecation.deprecated(reason="Prefer using 'bytecode'", deprecated_since="0.10.0beta")
     def getByteCode(self):
         return self.bytecode
 
-    @deprecation.deprecated(reason="Setting bytecode is not anymore allowed. If the data is not set use dtype instead.")
+    @deprecation.deprecated(reason="Setting bytecode is not anymore allowed. If the data is not set use dtype instead.", deprecated_since="0.10.0beta")
     def setByteCode(self, iVal=None, _iVal=None):
         raise NotImplementedError("No more implemented")
 
@@ -1125,11 +1125,11 @@ class EdfImage(fabioimage.FabioImage):
     def bytecode(self):
         return self._frames[self.currentframe].bytecode
 
-    @deprecation.deprecated(reason="Prefer using 'bpp'")
+    @deprecation.deprecated(reason="Prefer using 'bpp'", deprecated_since="0.10.0beta")
     def getBpp(self):
         return self._frames[self.currentframe].bpp
 
-    @deprecation.deprecated(reason="Setting bpp is not anymore allowed. If the data is not set use dtype instead.")
+    @deprecation.deprecated(reason="Setting bpp is not anymore allowed. If the data is not set use dtype instead.", deprecated_since="0.10.0beta")
     def setBpp(self, iVal=None, _iVal=None):
         raise NotImplementedError("No more implemented")
 
@@ -1137,7 +1137,7 @@ class EdfImage(fabioimage.FabioImage):
     def bpp(self):
         return self._frames[self.currentframe].bpp
 
-    @deprecation.deprecated(reason="Prefer using 'incomplete_data'")
+    @deprecation.deprecated(reason="Prefer using 'incomplete_data'", deprecated_since="0.10.0beta")
     def isIncompleteData(self):
         return self.incomplete_data
 

--- a/fabio/edfimage.py
+++ b/fabio/edfimage.py
@@ -61,6 +61,7 @@ from .fabioutils import isAscii, toAscii, nice_int, OrderedDict
 from .compression import decBzip2, decGzip, decZlib
 from . import compression as compression_module
 from . import fabioutils
+from .utils import deprecation
 
 
 BLOCKSIZE = 512
@@ -405,7 +406,7 @@ class EdfFrame(fabioimage.FabioFrame):
         """Setter for data in edf frame"""
         self._data = value
 
-    @fabioutils.deprecated(reason="Prefer using 'frame.data'")
+    @deprecation.deprecated(reason="Prefer using 'frame.data'")
     def getData(self):
         """
         Returns the data after unpacking it if needed.
@@ -414,7 +415,7 @@ class EdfFrame(fabioimage.FabioFrame):
         """
         return self.data
 
-    @fabioutils.deprecated(reason="Prefer using 'frame.data ='")
+    @deprecation.deprecated(reason="Prefer using 'frame.data ='")
     def setData(self, npa=None):
         """Setter for data in edf frame"""
         self._data = npa
@@ -525,7 +526,7 @@ class EdfFrame(fabioimage.FabioFrame):
         listHeader.append(" " * (headerSize - preciseSize) + "}\n")
         return ("".join(listHeader)).encode("ASCII") + data.tostring()
 
-    @fabioutils.deprecated(reason="Prefer using 'getEdfBlock'")
+    @deprecation.deprecated(reason="Prefer using 'getEdfBlock'")
     def getEdfBlock(self, force_type=None, fit2dMode=False):
         return self.get_edf_block(force_type, fit2dMode)
 
@@ -859,7 +860,7 @@ class EdfImage(fabioimage.FabioImage):
         else:
             self._frames.append(EdfFrame(data, header))
 
-    @fabioutils.deprecated(reason="Prefer using 'append_frame'")
+    @deprecation.deprecated(reason="Prefer using 'append_frame'")
     def appendFrame(self, frame=None, data=None, header=None):
         self.append_frame(frame, data, header)
 
@@ -873,7 +874,7 @@ class EdfImage(fabioimage.FabioImage):
         else:
             self._frames.pop(frameNb)
 
-    @fabioutils.deprecated(reason="Prefer using 'delete_frame'")
+    @deprecation.deprecated(reason="Prefer using 'delete_frame'")
     def deleteFrame(self, frameNb=None):
         self.delete_frame(frameNb)
 
@@ -900,7 +901,7 @@ class EdfImage(fabioimage.FabioImage):
             data.byteswap(True)
         return data
 
-    @fabioutils.deprecated(reason="Prefer using 'fastReadData'")
+    @deprecation.deprecated(reason="Prefer using 'fastReadData'")
     def fastReadData(self, filename):
         return self.fast_read_data(filename)
 
@@ -944,7 +945,7 @@ class EdfImage(fabioimage.FabioImage):
             data.byteswap(True)
         return data[slice2]
 
-    @fabioutils.deprecated(reason="Prefer using 'fast_read_roi'")
+    @deprecation.deprecated(reason="Prefer using 'fast_read_roi'")
     def fastReadROI(self, filename, coords=None):
         return self.fast_read_roi(filename, coords)
 
@@ -976,14 +977,14 @@ class EdfImage(fabioimage.FabioImage):
         """
         return len(self._frames)
 
-    @fabioutils.deprecated(reason="Prefer using 'img.nframes'")
+    @deprecation.deprecated(reason="Prefer using 'img.nframes'")
     def getNbFrames(self):
         """
         Getter for number of frames
         """
         return len(self._frames)
 
-    @fabioutils.deprecated(reason="This call to 'setNbFrames' does nothing and should be removed")
+    @deprecation.deprecated(reason="This call to 'setNbFrames' does nothing and should be removed")
     def setNbFrames(self, val):
         """
         Setter for number of frames ... should do nothing. Here just to avoid bugs
@@ -1006,14 +1007,14 @@ class EdfImage(fabioimage.FabioImage):
         frame = self._get_any_frame()
         frame.header = None
 
-    @fabioutils.deprecated(reason="Prefer using 'img.header'")
+    @deprecation.deprecated(reason="Prefer using 'img.header'")
     def getHeader(self):
         """
         Getter for the headers. used by the property header,
         """
         return self._frames[self.currentframe].header
 
-    @fabioutils.deprecated(reason="Prefer using 'img.header ='")
+    @deprecation.deprecated(reason="Prefer using 'img.header ='")
     def setHeader(self, _dictHeader):
         """
         Enforces the propagation of the header to the list of frames
@@ -1021,7 +1022,7 @@ class EdfImage(fabioimage.FabioImage):
         frame = self._get_any_frame()
         frame.header = _dictHeader
 
-    @fabioutils.deprecated(reason="Prefer using 'del img.header'")
+    @deprecation.deprecated(reason="Prefer using 'del img.header'")
     def delHeader(self):
         """
         Deleter for edf header
@@ -1053,7 +1054,7 @@ class EdfImage(fabioimage.FabioImage):
         frame = self._get_any_frame()
         frame.data = None
 
-    @fabioutils.deprecated(reason="Prefer using 'img.data'")
+    @deprecation.deprecated(reason="Prefer using 'img.data'")
     def getData(self):
         """
         getter for edf Data
@@ -1062,33 +1063,33 @@ class EdfImage(fabioimage.FabioImage):
         """
         return self.data
 
-    @fabioutils.deprecated(reason="Prefer using 'img.data ='")
+    @deprecation.deprecated(reason="Prefer using 'img.data ='")
     def setData(self, data=None, _data=None):
         """
         Enforces the propagation of the data to the list of frames
         :param data: numpy array representing data
         """
         if _data is not None:
-            fabioutils.deprecated_warning("Argument", "'_data'", replacement="argument 'data'", since_version=0.8)
+            deprecation.deprecated_warning("Argument", "'_data'", replacement="argument 'data'", since_version=0.8)
             data = _data
         frame = self._get_any_frame()
         frame.data = data
 
-    @fabioutils.deprecated(reason="Prefer using 'del img.data'")
+    @deprecation.deprecated(reason="Prefer using 'del img.data'")
     def delData(self):
         """
         deleter for edf Data
         """
         self._frames[self.currentframe].data = None
 
-    @fabioutils.deprecated(reason="Prefer using 'dim1'")
+    @deprecation.deprecated(reason="Prefer using 'dim1'")
     def getDim1(self):
         return self.dim1
 
-    @fabioutils.deprecated(reason="Setting dim1 is not anymore allowed. If the data is not set use shape instead.")
+    @deprecation.deprecated(reason="Setting dim1 is not anymore allowed. If the data is not set use shape instead.")
     def setDim1(self, iVal=None, _iVal=None):
         if _iVal is not None:
-            fabioutils.deprecated_warning("Argument", "'_iVal'", replacement="argument 'iVal'", since_version=0.8)
+            deprecation.deprecated_warning("Argument", "'_iVal'", replacement="argument 'iVal'", since_version=0.8)
             iVal = _iVal
         frame = self._get_any_frame()
         frame.dim1 = iVal
@@ -1097,14 +1098,14 @@ class EdfImage(fabioimage.FabioImage):
     def dim1(self):
         return self._frames[self.currentframe].dim1
 
-    @fabioutils.deprecated(reason="Prefer using 'dim2'")
+    @deprecation.deprecated(reason="Prefer using 'dim2'")
     def getDim2(self):
         return self._frames[self.currentframe].dim2
 
-    @fabioutils.deprecated(reason="Setting dim2 is not anymore allowed. If the data is not set use shape instead.")
+    @deprecation.deprecated(reason="Setting dim2 is not anymore allowed. If the data is not set use shape instead.")
     def setDim2(self, iVal=None, _iVal=None):
         if _iVal is not None:
-            fabioutils.deprecated_warning("Argument", "'_iVal'", replacement="argument 'iVal'", since_version=0.8)
+            deprecation.deprecated_warning("Argument", "'_iVal'", replacement="argument 'iVal'", since_version=0.8)
             iVal = _iVal
         frame = self._get_any_frame()
         frame.dim2 = iVal
@@ -1113,7 +1114,7 @@ class EdfImage(fabioimage.FabioImage):
     def dim2(self):
         return self._frames[self.currentframe].dim2
 
-    @fabioutils.deprecated(reason="Prefer using 'dims'")
+    @deprecation.deprecated(reason="Prefer using 'dims'")
     def getDims(self):
         return self._frames[self.currentframe].dims
 
@@ -1121,11 +1122,11 @@ class EdfImage(fabioimage.FabioImage):
     def dims(self):
         return self._frames[self.currentframe].dims
 
-    @fabioutils.deprecated(reason="Prefer using 'bytecode'")
+    @deprecation.deprecated(reason="Prefer using 'bytecode'")
     def getByteCode(self):
         return self.bytecode
 
-    @fabioutils.deprecated(reason="Setting bytecode is not anymore allowed. If the data is not set use dtype instead.")
+    @deprecation.deprecated(reason="Setting bytecode is not anymore allowed. If the data is not set use dtype instead.")
     def setByteCode(self, iVal=None, _iVal=None):
         raise NotImplementedError("No more implemented")
 
@@ -1133,11 +1134,11 @@ class EdfImage(fabioimage.FabioImage):
     def bytecode(self):
         return self._frames[self.currentframe].bytecode
 
-    @fabioutils.deprecated(reason="Prefer using 'bpp'")
+    @deprecation.deprecated(reason="Prefer using 'bpp'")
     def getBpp(self):
         return self._frames[self.currentframe].bpp
 
-    @fabioutils.deprecated(reason="Setting bpp is not anymore allowed. If the data is not set use dtype instead.")
+    @deprecation.deprecated(reason="Setting bpp is not anymore allowed. If the data is not set use dtype instead.")
     def setBpp(self, iVal=None, _iVal=None):
         raise NotImplementedError("No more implemented")
 
@@ -1145,7 +1146,7 @@ class EdfImage(fabioimage.FabioImage):
     def bpp(self):
         return self._frames[self.currentframe].bpp
 
-    @fabioutils.deprecated(reason="Prefer using 'incomplete_data'")
+    @deprecation.deprecated(reason="Prefer using 'incomplete_data'")
     def isIncompleteData(self):
         return self.incomplete_data
 

--- a/fabio/fabioimage.py
+++ b/fabio/fabioimage.py
@@ -64,40 +64,40 @@ class _FabioArray(object):
     :class:`FabioFrame`."""
 
     @property
-    @deprecation.deprecated(reason="Prefer using 'shape[-1]' instead of 'dim1'")
+    @deprecation.deprecated(reason="Prefer using 'shape[-1]' instead of 'dim1'", deprecated_since="0.10.0beta")
     def dim1(self):
         return self.shape[-1]
 
     @property
-    @deprecation.deprecated(reason="Prefer using 'shape[-2]' instead of 'dim2'")
+    @deprecation.deprecated(reason="Prefer using 'shape[-2]' instead of 'dim2'", deprecated_since="0.10.0beta")
     def dim2(self):
         return self.shape[-2]
 
     @property
-    @deprecation.deprecated(reason="Prefer using 'shape[-3]' instead of 'dim3'")
+    @deprecation.deprecated(reason="Prefer using 'shape[-3]' instead of 'dim3'", deprecated_since="0.10.0beta")
     def dim3(self):
         if len(self.shape) < 3:
             raise AttributeError("No attribye dim3")
         return self.shape[-3]
 
     @property
-    @deprecation.deprecated(reason="Prefer using 'shape' instead of 'dims' (the content in reverse order)")
+    @deprecation.deprecated(reason="Prefer using 'shape' instead of 'dims' (the content in reverse order)", deprecated_since="0.10.0beta")
     def dims(self):
         return list(reversed(self.shape))
 
-    @deprecation.deprecated(reason="Prefer using 'shape[-1]' instead of 'get_dim1'")
+    @deprecation.deprecated(reason="Prefer using 'shape[-1]' instead of 'get_dim1'", deprecated_since="0.10.0beta")
     def get_dim1(self):
         return self.shape[-1]
 
-    @deprecation.deprecated(reason="Prefer using 'shape[-2]' instead of 'get_dim2'")
+    @deprecation.deprecated(reason="Prefer using 'shape[-2]' instead of 'get_dim2'", deprecated_since="0.10.0beta")
     def get_dim2(self):
         return self.shape[-2]
 
-    @deprecation.deprecated(reason="Prefer using 'shape' instead of dim1/dim2")
+    @deprecation.deprecated(reason="Prefer using 'shape' instead of dim1/dim2", deprecated_since="0.10.0beta")
     def set_dim1(self, value):
         self.shape[-1] = value
 
-    @deprecation.deprecated(reason="Prefer using 'shape' instead of dim1/dim2")
+    @deprecation.deprecated(reason="Prefer using 'shape' instead of dim1/dim2", deprecated_since="0.10.0beta")
     def set_dim2(self, value):
         self.shape[-2] = value
 
@@ -227,7 +227,7 @@ class _FabioArray(object):
     def get_bytecode(self):
         return self.bytecode
 
-    @deprecation.deprecated(reason="Prefer using 'bytecode' instead of 'getByteCode'")
+    @deprecation.deprecated(reason="Prefer using 'bytecode' instead of 'getByteCode'", deprecated_since="0.10.0beta")
     def getByteCode(self):
         return self.bytecode
 

--- a/fabio/fabioimage.py
+++ b/fabio/fabioimage.py
@@ -44,7 +44,7 @@ __authors__ = ["Henning O. Sorensen", "Erik Knudsen", "Jon Wright", "Jérôme Ki
 __contact__ = "jerome.kieffer@esrf.fr"
 __license__ = "MIT"
 __copyright__ = "ESRF"
-__date__ = "14/11/2018"
+__date__ = "15/11/2018"
 
 import os
 import logging
@@ -56,6 +56,7 @@ import numpy
 from . import fabioutils, converters
 from .fabioutils import OrderedDict
 from .utils import pilutils
+from .utils import deprecation
 
 
 class _FabioArray(object):
@@ -63,40 +64,40 @@ class _FabioArray(object):
     :class:`FabioFrame`."""
 
     @property
-    @fabioutils.deprecated(reason="Prefer using 'shape[-1]' instead of 'dim1'")
+    @deprecation.deprecated(reason="Prefer using 'shape[-1]' instead of 'dim1'")
     def dim1(self):
         return self.shape[-1]
 
     @property
-    @fabioutils.deprecated(reason="Prefer using 'shape[-2]' instead of 'dim2'")
+    @deprecation.deprecated(reason="Prefer using 'shape[-2]' instead of 'dim2'")
     def dim2(self):
         return self.shape[-2]
 
     @property
-    @fabioutils.deprecated(reason="Prefer using 'shape[-3]' instead of 'dim3'")
+    @deprecation.deprecated(reason="Prefer using 'shape[-3]' instead of 'dim3'")
     def dim3(self):
         if len(self.shape) < 3:
             raise AttributeError("No attribye dim3")
         return self.shape[-3]
 
     @property
-    @fabioutils.deprecated(reason="Prefer using 'shape' instead of 'dims' (the content in reverse order)")
+    @deprecation.deprecated(reason="Prefer using 'shape' instead of 'dims' (the content in reverse order)")
     def dims(self):
         return list(reversed(self.shape))
 
-    @fabioutils.deprecated(reason="Prefer using 'shape[-1]' instead of 'get_dim1'")
+    @deprecation.deprecated(reason="Prefer using 'shape[-1]' instead of 'get_dim1'")
     def get_dim1(self):
         return self.shape[-1]
 
-    @fabioutils.deprecated(reason="Prefer using 'shape[-2]' instead of 'get_dim2'")
+    @deprecation.deprecated(reason="Prefer using 'shape[-2]' instead of 'get_dim2'")
     def get_dim2(self):
         return self.shape[-2]
 
-    @fabioutils.deprecated(reason="Prefer using 'shape' instead of dim1/dim2")
+    @deprecation.deprecated(reason="Prefer using 'shape' instead of dim1/dim2")
     def set_dim1(self, value):
         self.shape[-1] = value
 
-    @fabioutils.deprecated(reason="Prefer using 'shape' instead of dim1/dim2")
+    @deprecation.deprecated(reason="Prefer using 'shape' instead of dim1/dim2")
     def set_dim2(self, value):
         self.shape[-2] = value
 
@@ -226,7 +227,7 @@ class _FabioArray(object):
     def get_bytecode(self):
         return self.bytecode
 
-    @fabioutils.deprecated(reason="Prefer using 'bytecode' instead of 'getByteCode'")
+    @deprecation.deprecated(reason="Prefer using 'bytecode' instead of 'getByteCode'")
     def getByteCode(self):
         return self.bytecode
 
@@ -329,7 +330,7 @@ class FabioImage(_FabioArray):
     # List of header keys which are reserved by the file format
 
     @classmethod
-    @fabioutils.deprecated
+    @deprecation.deprecated
     def factory(cls, name):
         """A kind of factory... for image_classes
 

--- a/fabio/fabioutils.py
+++ b/fabio/fabioutils.py
@@ -38,7 +38,7 @@ __author__ = "Jérôme Kieffer"
 __contact__ = "Jerome.Kieffer@ESRF.eu"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
-__date__ = "13/11/2018"
+__date__ = "15/11/2018"
 __status__ = "stable"
 __docformat__ = 'restructuredtext'
 
@@ -61,10 +61,6 @@ except ImportError:
         import pathlib2 as pathlib
     except ImportError:
         pathlib = None
-
-depreclog = logging.getLogger("fabio.DEPRECATION")
-
-deprecache = set([])
 
 if six.PY2:
     bytes_ = str
@@ -95,85 +91,6 @@ else:
     from threading import Semaphore as _Semaphore
 
 dictAscii = {None: [chr(i) for i in range(32, 127)]}
-
-
-def deprecated(func=None, reason=None, replacement=None, since_version=None, only_once=True, skip_backtrace_count=1):
-    """
-    Decorator that deprecates the use of a function
-
-    :param str reason: Reason for deprecating this function
-        (e.g. "feature no longer provided",
-    :param str replacement: Name of replacement function (if the reason for
-        deprecating was to rename the function)
-    :param str since_version: First *silx* version for which the function was
-        deprecated (e.g. "0.5.0").
-    :param bool only_once: If true, the deprecation warning will only be
-        generated one time. Default is true.
-    :param int skip_backtrace_count: Amount of last backtrace to ignore when
-        logging the backtrace
-    """
-    def decorator(func):
-        @functools.wraps(func)
-        def wrapper(*args, **kwargs):
-            name = func.func_name if sys.version_info[0] < 3 else func.__name__
-
-            deprecated_warning(type_='Function',
-                               name=name,
-                               reason=reason,
-                               replacement=replacement,
-                               since_version=since_version,
-                               only_once=only_once,
-                               skip_backtrace_count=skip_backtrace_count)
-            return func(*args, **kwargs)
-        return wrapper
-    if func is not None:
-        return decorator(func)
-    return decorator
-
-
-def deprecated_warning(type_, name, reason=None, replacement=None,
-                       since_version=None, only_once=True,
-                       skip_backtrace_count=0):
-    """
-    Function to log a deprecation warning
-
-    :param str type_: Nature of the object to be deprecated:
-        "Module", "Function", "Class" ...
-    :param name: Object name.
-    :param str reason: Reason for deprecating this function
-        (e.g. "feature no longer provided",
-    :param str replacement: Name of replacement function (if the reason for
-        deprecating was to rename the function)
-    :param str since_version: First *silx* version for which the function was
-        deprecated (e.g. "0.5.0").
-    :param bool only_once: If true, the deprecation warning will only be
-        generated one time for each different call locations. Default is true.
-    :param int skip_backtrace_count: Amount of last backtrace to ignore when
-        logging the backtrace
-    """
-    if not depreclog.isEnabledFor(logging.WARNING):
-        # Avoid computation when it is not logged
-        return
-
-    msg = "%s %s is deprecated"
-    if since_version is not None:
-        msg += " since silx version %s" % since_version
-    msg += "."
-    if reason is not None:
-        msg += " Reason: %s." % reason
-    if replacement is not None:
-        msg += " Use '%s' instead." % replacement
-    msg += "\n%s"
-    limit = 2 + skip_backtrace_count
-    backtrace = "".join(traceback.format_stack(limit=limit)[0])
-    backtrace = backtrace.rstrip()
-    if only_once:
-        data = (msg, type_, name, backtrace)
-        if data in deprecache:
-            return
-        else:
-            deprecache.add(data)
-    depreclog.warning(msg, type_, name, backtrace)
 
 
 def pad(mystr, pattern=" ", size=80):

--- a/fabio/utils/deprecation.py
+++ b/fabio/utils/deprecation.py
@@ -1,0 +1,119 @@
+# coding: utf-8
+# /*##########################################################################
+#
+# Copyright (c) 2016-2017 European Synchrotron Radiation Facility
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+# ###########################################################################*/
+"""Bunch of useful decorators"""
+
+from __future__ import absolute_import, print_function, division
+
+__authors__ = ["Jerome Kieffer", "H. Payno", "P. Knobel"]
+__license__ = "MIT"
+__date__ = "15/11/2018"
+
+import sys
+import logging
+import functools
+import traceback
+
+depreclog = logging.getLogger("fabio.DEPRECATION")
+
+deprecache = set([])
+
+
+def deprecated(func=None, reason=None, replacement=None, since_version=None, only_once=True, skip_backtrace_count=1):
+    """
+    Decorator that deprecates the use of a function
+
+    :param str reason: Reason for deprecating this function
+        (e.g. "feature no longer provided",
+    :param str replacement: Name of replacement function (if the reason for
+        deprecating was to rename the function)
+    :param str since_version: First *silx* version for which the function was
+        deprecated (e.g. "0.5.0").
+    :param bool only_once: If true, the deprecation warning will only be
+        generated one time. Default is true.
+    :param int skip_backtrace_count: Amount of last backtrace to ignore when
+        logging the backtrace
+    """
+    def decorator(func):
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            name = func.func_name if sys.version_info[0] < 3 else func.__name__
+
+            deprecated_warning(type_='Function',
+                               name=name,
+                               reason=reason,
+                               replacement=replacement,
+                               since_version=since_version,
+                               only_once=only_once,
+                               skip_backtrace_count=skip_backtrace_count)
+            return func(*args, **kwargs)
+        return wrapper
+    if func is not None:
+        return decorator(func)
+    return decorator
+
+
+def deprecated_warning(type_, name, reason=None, replacement=None,
+                       since_version=None, only_once=True,
+                       skip_backtrace_count=0):
+    """
+    Function to log a deprecation warning
+
+    :param str type_: Nature of the object to be deprecated:
+        "Module", "Function", "Class" ...
+    :param name: Object name.
+    :param str reason: Reason for deprecating this function
+        (e.g. "feature no longer provided",
+    :param str replacement: Name of replacement function (if the reason for
+        deprecating was to rename the function)
+    :param str since_version: First *silx* version for which the function was
+        deprecated (e.g. "0.5.0").
+    :param bool only_once: If true, the deprecation warning will only be
+        generated one time for each different call locations. Default is true.
+    :param int skip_backtrace_count: Amount of last backtrace to ignore when
+        logging the backtrace
+    """
+    if not depreclog.isEnabledFor(logging.WARNING):
+        # Avoid computation when it is not logged
+        return
+
+    msg = "%s %s is deprecated"
+    if since_version is not None:
+        msg += " since silx version %s" % since_version
+    msg += "."
+    if reason is not None:
+        msg += " Reason: %s." % reason
+    if replacement is not None:
+        msg += " Use '%s' instead." % replacement
+    msg += "\n%s"
+    limit = 2 + skip_backtrace_count
+    backtrace = "".join(traceback.format_stack(limit=limit)[0])
+    backtrace = backtrace.rstrip()
+    if only_once:
+        data = (msg, type_, name, backtrace)
+        if data in deprecache:
+            return
+        else:
+            deprecache.add(data)
+    depreclog.warning(msg, type_, name, backtrace)

--- a/fabio/utils/deprecation.py
+++ b/fabio/utils/deprecation.py
@@ -56,7 +56,7 @@ def deprecated(func=None, reason=None, replacement=None, since_version=None,
         (e.g. "feature no longer provided",
     :param str replacement: Name of replacement function (if the reason for
         deprecating was to rename the function)
-    :param str since_version: First *silx* version for which the function was
+    :param str since_version: First *fabio* version for which the function was
         deprecated (e.g. "0.5.0").
     :param bool only_once: If true, the deprecation warning will only be
         generated one time. Default is true.
@@ -99,7 +99,7 @@ def deprecated_warning(type_, name, reason=None, replacement=None,
         (e.g. "feature no longer provided",
     :param str replacement: Name of replacement function (if the reason for
         deprecating was to rename the function)
-    :param str since_version: First *silx* version for which the function was
+    :param str since_version: First *fabio* version for which the function was
         deprecated (e.g. "0.5.0").
     :param bool only_once: If true, the deprecation warning will only be
         generated one time for each different call locations. Default is true.
@@ -114,7 +114,7 @@ def deprecated_warning(type_, name, reason=None, replacement=None,
 
     msg = "%s %s is deprecated"
     if since_version is not None:
-        msg += " since silx version %s" % since_version
+        msg += " since fabio version %s" % since_version
     msg += "."
     if reason is not None:
         msg += " Reason: %s." % reason

--- a/version.py
+++ b/version.py
@@ -63,7 +63,6 @@ __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
 __date__ = "15/11/2018"
 __status__ = "production"
 __docformat__ = 'restructuredtext'
-__all__ = ["date", "version_info", "strictversion", "hexversion", "debianversion"]
 
 RELEASE_LEVEL_VALUE = {"dev": 0,
                        "alpha": 10,
@@ -93,8 +92,10 @@ if version_info.releaselevel != "final":
         prerel = "a"
     strictversion += prerel + str(version_info[-1])
 
+_PATTERN = None
 
-def calc_hexversion(major=0, minor=0, micro=0, releaselevel="dev", serial=0):
+
+def calc_hexversion(major=0, minor=0, micro=0, releaselevel="dev", serial=0, string=None):
     """Calculate the hexadecimal version number from the tuple version_info:
 
     :param major: integer
@@ -104,6 +105,20 @@ def calc_hexversion(major=0, minor=0, micro=0, releaselevel="dev", serial=0):
     :param serial: integer
     :return: integer always increasing with revision numbers
     """
+    if string is not None:
+        global _PATTERN
+        if _PATTERN is None:
+            import re
+            _PATTERN = re.compile(r"(\d+)\.(\d+)\.(\d+)(\w+)?$")
+        result = _PATTERN.match(string)
+        if result is None:
+            raise ValueError("'%s' is not a valid version" % string)
+        result = result.groups()
+        major, minor, micro = int(result[0]), int(result[1]), int(result[2])
+        releaselevel = result[3]
+        if releaselevel is None:
+            releaselevel = 0
+
     try:
         releaselevel = int(releaselevel)
     except ValueError:

--- a/version.py
+++ b/version.py
@@ -60,7 +60,7 @@ __author__ = "Jerome Kieffer"
 __contact__ = "Jerome.Kieffer@ESRF.eu"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
-__date__ = "26/06/2018"
+__date__ = "15/11/2018"
 __status__ = "production"
 __docformat__ = 'restructuredtext'
 __all__ = ["date", "version_info", "strictversion", "hexversion", "debianversion"]
@@ -93,11 +93,32 @@ if version_info.releaselevel != "final":
         prerel = "a"
     strictversion += prerel + str(version_info[-1])
 
-hexversion = version_info[4]
-hexversion |= RELEASE_LEVEL_VALUE.get(version_info[3], 0) * 1 << 4
-hexversion |= version_info[2] * 1 << 8
-hexversion |= version_info[1] * 1 << 16
-hexversion |= version_info[0] * 1 << 24
+
+def calc_hexversion(major=0, minor=0, micro=0, releaselevel="dev", serial=0):
+    """Calculate the hexadecimal version number from the tuple version_info:
+
+    :param major: integer
+    :param minor: integer
+    :param micro: integer
+    :param relev: integer or string
+    :param serial: integer
+    :return: integer always increasing with revision numbers
+    """
+    try:
+        releaselevel = int(releaselevel)
+    except ValueError:
+        releaselevel = RELEASE_LEVEL_VALUE.get(releaselevel, 0)
+
+    hex_version = int(serial)
+    hex_version |= releaselevel * 1 << 4
+    hex_version |= int(micro) * 1 << 8
+    hex_version |= int(minor) * 1 << 16
+    hex_version |= int(major) * 1 << 24
+    return hex_version
+
+
+hexversion = calc_hexversion(*version_info)
+
 
 if __name__ == "__main__":
     print(version)


### PR DESCRIPTION
This PR plan the deprecation warnings for fabio 0.10.0beta, while allowing to display pending deprecation warning if requested.

```
# Here nothing is displayed
import fabio
image = fabio.open("../data/edf/medipix.edf")
image.getData()
```

```
# Using this logging command will allow project to check and fix warnings using fabio 0.9
import logging
logging.getLogger("fabio.DEPRECATION").setLevel(logging.DEBUG)

import fabio
image = fabio.open("../data/edf/medipix.edf")
image.getData()
DEBUG:fabio.DEPRECATION:Function getData is deprecated. Reason: Prefer using 'img.data'.
  File "<ipython-input-5-94eb0a625094>", line 1, in <module>
    image.getData()
```