### PR TITLE
Close HDF5 from fabio image

### DIFF
--- a/fabio/eigerimage.py
+++ b/fabio/eigerimage.py
@@ -48,7 +48,7 @@ __authors__ = ["Jérôme Kieffer"]
 __contact__ = "jerome.kieffer@esrf.fr"
 __license__ = "MIT"
 __copyright__ = "ESRF"
-__date__ = "14/11/2018"
+__date__ = "01/03/2019"
 
 import logging
 logger = logging.getLogger(__name__)
@@ -200,6 +200,11 @@ class EigerImage(FabioImage):
     def next(self):
         """ returns the next frame in the series as a fabioimage """
         return self.getframe(self.currentframe + 1)
+
+    def close(self):
+        if self.h5 is not None:
+            self.h5.close()
+            self.dataset = None
 
 
 eigerimage = EigerImage

--- a/fabio/hdf5image.py
+++ b/fabio/hdf5image.py
@@ -44,7 +44,7 @@ __authors__ = ["Jérôme Kieffer"]
 __contact__ = "Jerome.Kieffer@terre-adelie.org"
 __license__ = "MIT"
 __copyright__ = "Jérôme Kieffer"
-__date__ = "14/11/2018"
+__date__ = "01/03/2019"
 
 import logging
 import os
@@ -177,6 +177,11 @@ class Hdf5Image(fabioimage.FabioImage):
             newobj = Hdf5Image()
             newobj.read(previous_filename(self.filename))
             return newobj
+
+    def close(self):
+        if self.hdf5 is not None:
+            self.hdf5.close()
+            self.dataset = None
 
 
 hdf5image = Hdf5Image


### PR DESCRIPTION
HDF5 file was not closed when the FabioImage was not anymore needed.

This should improve the things especially on Windows.