### PR TITLE
Improvement to read d*TREK

### DIFF
--- a/fabio/adscimage.py
+++ b/fabio/adscimage.py
@@ -92,7 +92,7 @@ class AdscImage(FabioImage):
         """ read an adsc header """
         line = infile.readline()
         bytesread = len(line)
-        while b'}' not in line:
+        while line != b'}\n':
             if b'=' in line:
                 (key, val) = to_str(line).split('=')
                 self.header[key.strip()] = val.strip(' ;\n\r')

--- a/fabio/adscimage.py
+++ b/fabio/adscimage.py
@@ -72,7 +72,13 @@ class AdscImage(FabioImage):
             binary = infile.read()
         # infile.close()
 
-        dtype = numpy.dtype(numpy.uint16)
+        # NOTE: Used by the d*TREK format
+        data_mode = self.header.get("PXD_DETECTOR_ACQUISITION_DATAMODE", None)
+        if data_mode == "Combined 31bit":
+            dtype = numpy.dtype(numpy.uint32)
+        else:
+            dtype = numpy.dtype(numpy.uint16)
+
         # now read the data into the array
         self._shape = int(self.header['SIZE2']), int(self.header['SIZE1'])
         data = numpy.frombuffer(binary, dtype).copy()

--- a/fabio/adscimage.py
+++ b/fabio/adscimage.py
@@ -72,9 +72,10 @@ class AdscImage(FabioImage):
             binary = infile.read()
         # infile.close()
 
+        dtype = numpy.dtype(numpy.uint16)
         # now read the data into the array
         self._shape = int(self.header['SIZE2']), int(self.header['SIZE1'])
-        data = numpy.frombuffer(binary, numpy.uint16).copy()
+        data = numpy.frombuffer(binary, dtype).copy()
         if self.swap_needed():
             data.byteswap(True)
         try:

--- a/fabio/openimage.py
+++ b/fabio/openimage.py
@@ -221,7 +221,7 @@ def _openimage(filename):
                 raise Exception("openimage failed on magic bytes & name guess")
             filetype = file_obj.format
 
-        except Exception as error:
+        except Exception:
             logger.debug("Backtrace", exc_info=True)
             raise IOError("Fabio could not identify " + filename)
 

--- a/fabio/openimage.py
+++ b/fabio/openimage.py
@@ -199,9 +199,9 @@ def _openimage(filename):
         imo = FabioImage()
         with imo._open(actual_filename) as f:
             magic_bytes = f.read(18)
-    except IOError as error:
-        logger.debug("%s: File probably does not exist", error)
-        raise error
+    except IOError:
+        logger.debug("Backtrace", exc_info=True)
+        raise
     else:
         imo = None
 


### PR DESCRIPTION
This is a dirty patch to read a very specific d*TREK format using the ADSC reader.

The data read was not checked, then maybe it is still not working anyway.

Only the last commit is dirty, the other ones are part of the PR #300

The parsing of the d*TREK should be done in a specific reader and not merged into the ADSC one. But maybe what we call ADSC in fabio is d*TREK, or maybe d*TREK was designed as a superset of ADSC. No idea.