### PR TITLE
Fix change of default for numpy.load allow_pickle arg

### DIFF
--- a/fabio/numpyimage.py
+++ b/fabio/numpyimage.py
@@ -158,7 +158,7 @@ class NumpyImage(fabioimage.FabioImage):
         self._readheader(infile)
 
         # read the image data
-        self.dataset = numpy.load(infile)
+        self.dataset = numpy.load(infile, allow_pickle=True)
         self.slice_dataset(frame)
         return self
 


### PR DESCRIPTION
This PR makes `fabio` tests pass with `numpy` 1.16.3.
The issue is due to a change of default value of the `allow_pickle` argument of `numpy.load` from True to False due to security issue.
This fix just set `allow_pickle` to True... which makes a security vulnerability (see https://github.com/numpy/numpy/blob/master/numpy/lib/npyio.py#L316)

closes #313