### PR TITLE
Do not create a temporary string (it slows down writing on windows)

### DIFF
--- a/fabio/edfimage.py
+++ b/fabio/edfimage.py
@@ -593,7 +593,7 @@ class EdfFrame(fabioimage.FabioFrame):
 
         # Then update static headers freshly deleted
         header_keys.insert(0, "Size")
-        header["Size"] = len(data.tostring())
+        header["Size"] = data.nbytes
         header_keys.insert(0, "HeaderID")
         header["HeaderID"] = "EH:%06d:000000:000000" % (self.index + fit2dMode)
         header_keys.insert(0, "Image")


### PR DESCRIPTION
Presumably a windows thing - it takes 50 ms to run this tostring line for a 2048x2048 image
Issue noticed on python3.7 64 bits and windows 10.