### PR TITLE
Make EDF magic it readable

### DIFF
--- a/fabio/openimage.py
+++ b/fabio/openimage.py
@@ -68,11 +68,11 @@ MAGIC_NUMBERS = [
     # d*TREK must come before edf
     (b"{\nHEA", 'dtrek'),
     # EDF_ types 
-    (b"\x0d\x0a\x7b\x0d\x0a\x45\x44\x46",'edf'),  # EDF3 (can be interpreted like EDF1 but refused by fit2d)
-    (b"\x0a\x7b\x0d\x0a\x45\x44\x46",'edf'),      # EDF2 (can be interpreted like EDF1 but refused by fit2d)
-    (b"\x7b\x0d\x0a\x45\x44\x46",'edf'),          # EDF1 (EDF >=V2.4 starting with EDF_, fit2d friendly, without starting newline)
-    (b"\x7b\x0a",'edf'),                          # EDF0 (EDF V1.xx "standard", without additional EDF_ structure information)
-    (b"\x0a\x7b\x0a",'edf'),                      # EDFU (EDF unknown source, V1.xx)
+    (b"\r\n{\r\nEDF",'edf'),   # EDF3 (can be interpreted like EDF1 but refused by fit2d)
+    (b"\n{\r\nEDF",'edf'),     # EDF2 (can be interpreted like EDF1 but refused by fit2d)
+    (b"{\r\nEDF",'edf'),       # EDF1 (EDF >=V2.4 starting with EDF_, fit2d friendly, without starting newline)
+    (b"{\n",'edf'),            # EDF0 (EDF V1.xx "standard", without additional EDF_ structure information)
+    (b"\n{\n",'edf'),          # EDFU (EDF unknown source, V1.xx)
     # conventional
     (b"{", 'edf'),
     (b"\r{", 'edf'),


### PR DESCRIPTION
This PR make the EDF magic readable.

As result, we can easily see that there is dup:
- b"\n{\r\nEDF" is already triggered by b"\n{"
- b"{\r\nEDF" is already triggered by b"{"
- b"{\n"  is already triggered by b"{"
- b"\n{\n",'edf') is already triggered by b"\n{"

I let you see what to do with this information.