### PR TITLE
Fix BytesIO

### DIFF
--- a/fabio/openimage.py
+++ b/fabio/openimage.py
@@ -188,10 +188,12 @@ def _openimage(filename):
 
     """
     if hasattr(filename, "seek") and hasattr(filename, "read"):
-        # Looks to be a file containing filenames
-        if not isinstance(filename, BytesIO):
-            filename.seek(0)
-            actual_filename = BytesIO(filename.read())
+        # Data stream without filename
+        filename.seek(0)
+        data = filename.read()
+        actual_filename = fabioutils.BytesIO(data)
+        # Back to the location before the read
+        filename.seek(0)
     else:
         if os.path.exists(filename):
             # Already a valid filename

--- a/fabio/test/test_fabio.py
+++ b/fabio/test/test_fabio.py
@@ -30,6 +30,7 @@ Basically everything supposed to be provided by `import fabio`
 
 import unittest
 import logging
+import io
 
 logger = logging.getLogger(__name__)
 
@@ -45,6 +46,26 @@ class TestFabio(unittest.TestCase):
         image = fabio.open(filename)
         image.data
         image.close()
+
+    def test_open_bytesio(self):
+        filename = UtilsTest.getimage("multiframes.edf.bz2")
+        filename = filename.replace(".bz2", "")
+        with io.open(filename, "rb") as f:
+            data = f.read()
+            mem = io.BytesIO(data)
+            with fabio.open(mem) as image:
+                self.assertIsNotNone(image)
+                self.assertEqual(image.nframes, 8)
+
+    def test_open_fabio_bytesio(self):
+        filename = UtilsTest.getimage("multiframes.edf.bz2")
+        filename = filename.replace(".bz2", "")
+        with io.open(filename, "rb") as f:
+            data = f.read()
+            mem = fabio.fabioutils.BytesIO(data)
+            with fabio.open(mem) as image:
+                self.assertIsNotNone(image)
+                self.assertEqual(image.nframes, 8)
 
     def test_open_with(self):
         filename = UtilsTest.getimage("multiframes.edf.bz2")


### PR DESCRIPTION
The `_openimage` was never tested.

There is a regression in 0.10, so it was not possible to read `BytesIO` with `fabio.open`.

This is only a fix which could be part to a bug fix.

The `_openimage` should be reworked. This code is reading twice the streams (read the full data for the magic, then read again the full data to parse the stream). This should be avoided, if you deal will standard compressed streams, it's just not efficient, and maybe buggy.
