### PR TITLE
Robustness on EDF header

### DIFF
--- a/fabio/edfimage.py
+++ b/fabio/edfimage.py
@@ -1022,9 +1022,13 @@ class EdfImage(fabioimage.FabioImage):
                 key = key.strip(bytes_whitespace)
                 val = val.strip(bytes_whitespace)
                 try:
-                    header[key.decode("ASCII")] = val.decode("ASCII")
+                    key, val = key.decode("ASCII"), val.decode("ASCII")
                 except:
-                    logger.warning("Non ASCII in header: %s %s", repr(key), repr(val))
+                    logger.warning("Non ASCII in key-value: Drop %s = %s", key, val)
+                else:
+                    if key in header:
+                        logger.warning("Duplicated key: Drop %s = %s", key, header[key])
+                    header[key] = val
 
         # Read EDF_ keys
         # if the header block starts with EDF_DataFormatVersion, it is a general block

--- a/fabio/edfimage.py
+++ b/fabio/edfimage.py
@@ -1029,6 +1029,10 @@ class EdfImage(fabioimage.FabioImage):
                     if key in header:
                         logger.warning("Duplicated key: Drop %s = %s", key, header[key])
                     header[key] = val
+            else:
+                line = line.strip(bytes_whitespace)
+                if line != b"":
+                    logger.debug("Non key-value line: %s", line)
 
         # Read EDF_ keys
         # if the header block starts with EDF_DataFormatVersion, it is a general block

--- a/fabio/edfimage.py
+++ b/fabio/edfimage.py
@@ -1021,16 +1021,10 @@ class EdfImage(fabioimage.FabioImage):
                 key, val = line.split(b'=', 1)
                 key = key.strip(bytes_whitespace)
                 val = val.strip(bytes_whitespace)
-                # do the decode here for each item:
                 try:
-                    key = key.decode("ASCII")
+                    header[key.decode("ASCII")] = val.decode("ASCII")
                 except:
-                    logging.warn("Non ascii data in your header %s"%(key))
-                try:
-                    val = val.decode("ASCII")
-                except:
-                    logging.warn("Non ascii data in your header %s"%(val))
-                header[key] = val
+                    logger.warning("Non ASCII in header: %s %s", repr(key), repr(val))
 
         # Read EDF_ keys
         # if the header block starts with EDF_DataFormatVersion, it is a general block

--- a/fabio/test/codecs/test_edfimage.py
+++ b/fabio/test/codecs/test_edfimage.py
@@ -636,6 +636,45 @@ class TestEdfIterator(unittest.TestCase):
             next(iterator)
 
 
+
+class TestEdfBadHeaderPadding(unittest.TestCase):
+    """
+    Some old data were found with headers padded with 0xcd (issue #373)
+    """
+    def setUp(self):
+        self.fgood = "TestEdfGoodHeaderPadding.edf"
+        self.fbad = "TestEdfBadHeaderPadding.edf"
+        self.data = numpy.zeros( (10,11), numpy.uint8 )
+        self.hdr = { "mykey"  : "myvalue" }
+        fabio.edfimage.edfimage( self.data, self.hdr ).write(self.fgood)
+        with open( self.fgood, "rb") as fh:
+            hdr = bytearray( fh.read(512) )
+            while hdr.find(b"}")<0:
+                hdr += fh.read(512)
+            start = hdr.rfind( b";" )+1
+            end = hdr.find(b"}")-1
+            hdr[start:end] = [ord('\n'),] + [0xcd,]*(end-start-1)
+            with open( self.fbad, "wb") as fb:
+                fb.write( hdr )
+                fb.write( fh.read() )
+
+    def tearDown(self):
+        os.remove(self.fgood)
+        os.remove(self.fbad)
+
+    def testReadBadPadding(self):
+        im = fabio.open(self.fbad)
+        self.assertTrue( (im.data == 0).all() )
+        for k in self.hdr.keys():
+            self.assertEqual( self.hdr[k], im.header[k] )
+
+    def testReadGoodPadding(self):
+        im = fabio.open(self.fgood)
+        self.assertTrue( (im.data == 0).all() )
+        for k in self.hdr.keys():
+            self.assertEqual( self.hdr[k], im.header[k] )
+
+
 def suite():
     loadTests = unittest.defaultTestLoader.loadTestsFromTestCase
     testsuite = unittest.TestSuite()
@@ -652,6 +691,7 @@ def suite():
     testsuite.addTest(loadTests(TestBadGzFiles))
     testsuite.addTest(loadTests(TestEdfIterator))
     testsuite.addTest(loadTests(TestSphere2SaxsSamples))
+    testsuite.addTest(loadTests(TestEdfBadHeaderPadding))
     return testsuite
 
 

--- a/fabio/test/codecs/test_edfimage.py
+++ b/fabio/test/codecs/test_edfimage.py
@@ -644,6 +644,7 @@ class TestEdfBadHeaderPadding(unittest.TestCase):
     def setUp(self):
         self.fgood = "TestEdfGoodHeaderPadding.edf"
         self.fbad = "TestEdfBadHeaderPadding.edf"
+        self.fzero = "TestEdfZeroHeaderPadding.edf"
         self.data = numpy.zeros( (10,11), numpy.uint8 )
         self.hdr = { "mykey"  : "myvalue" }
         fabio.edfimage.edfimage( self.data, self.hdr ).write(self.fgood)
@@ -657,10 +658,18 @@ class TestEdfBadHeaderPadding(unittest.TestCase):
             with open( self.fbad, "wb") as fb:
                 fb.write( hdr )
                 fb.write( fh.read() )
+            # insert some 0x00 to be stripped
+            key = b"myvalue"
+            z = hdr.find(key)
+            hdr[z+len(key)] = 0
+            with open( self.fzero, "wb") as fb:
+                fb.write( hdr )
+                fb.write( fh.read() )
 
     def tearDown(self):
         os.remove(self.fgood)
         os.remove(self.fbad)
+        os.remove(self.fzero)
 
     def testReadBadPadding(self):
         im = fabio.open(self.fbad)
@@ -670,6 +679,12 @@ class TestEdfBadHeaderPadding(unittest.TestCase):
 
     def testReadGoodPadding(self):
         im = fabio.open(self.fgood)
+        self.assertTrue( (im.data == 0).all() )
+        for k in self.hdr.keys():
+            self.assertEqual( self.hdr[k], im.header[k] )
+
+    def testReadZeroPadding(self):
+        im = fabio.open(self.fzero)
         self.assertTrue( (im.data == 0).all() )
         for k in self.hdr.keys():
             self.assertEqual( self.hdr[k], im.header[k] )

--- a/fabio/test/codecs/test_edfimage.py
+++ b/fabio/test/codecs/test_edfimage.py
@@ -645,6 +645,7 @@ class TestEdfBadHeaderPadding(unittest.TestCase):
         self.fgood = "TestEdfGoodHeaderPadding.edf"
         self.fbad = "TestEdfBadHeaderPadding.edf"
         self.fzero = "TestEdfZeroHeaderPadding.edf"
+        self.fbytes = "TestEdfBytesItem.edf"
         self.data = numpy.zeros( (10,11), numpy.uint8 )
         self.hdr = { "mykey"  : "myvalue" }
         fabio.edfimage.edfimage( self.data, self.hdr ).write(self.fgood)
@@ -652,19 +653,25 @@ class TestEdfBadHeaderPadding(unittest.TestCase):
             hdr = bytearray( fh.read(512) )
             while hdr.find(b"}")<0:
                 hdr += fh.read(512)
+            data = fh.read()
+        with open( self.fbad, "wb") as fb:
             start = hdr.rfind( b";" )+1
             end = hdr.find(b"}")-1
             hdr[start:end] = [ord('\n'),] + [0xcd,]*(end-start-1)
-            with open( self.fbad, "wb") as fb:
-                fb.write( hdr )
-                fb.write( fh.read() )
+            fb.write( hdr )
+            fb.write( data )
+        with open( self.fzero, "wb") as fb:
             # insert some 0x00 to be stripped
             key = b"myvalue"
             z = hdr.find(key)
             hdr[z+len(key)] = 0
-            with open( self.fzero, "wb") as fb:
+            fb.write( hdr )
+            fb.write( data )
+        with open( self.fbytes, "wb") as fb:
+            hdr[z:z+1]=0xc3,0xa9 # e-acute in utf-8 ??
+            with open( self.fbytes, "wb") as fb:
                 fb.write( hdr )
-                fb.write( fh.read() )
+                fb.write( data )
 
     def tearDown(self):
         os.remove(self.fgood)
@@ -689,7 +696,16 @@ class TestEdfBadHeaderPadding(unittest.TestCase):
         for k in self.hdr.keys():
             self.assertEqual( self.hdr[k], im.header[k] )
 
+    def testBytesitem(self):
+        im = fabio.open(self.fbytes)
+        self.assertTrue( (im.data == 0).all() )
+        for k in self.hdr.keys():
+            self.assertTrue( k in im.header )
+            val = im.header[k]
+            self.assertNotEqual( self.hdr[k], im.header[k] )
+            
 
+            
 def suite():
     loadTests = unittest.defaultTestLoader.loadTestsFromTestCase
     testsuite = unittest.TestSuite()

--- a/fabio/test/codecs/test_edfimage.py
+++ b/fabio/test/codecs/test_edfimage.py
@@ -647,7 +647,7 @@ class TestEdfBadHeaderPadding(unittest.TestCase):
         self.fzero = "TestEdfZeroHeaderPadding.edf"
         self.fbytes = "TestEdfBytesItem.edf"
         self.data = numpy.zeros( (10,11), numpy.uint8 )
-        self.hdr = { "mykey"  : "myvalue" }
+        self.hdr = { "mykey"  : "myvalue", "title" : "ok" }
         fabio.edfimage.edfimage( self.data, self.hdr ).write(self.fgood)
         with open( self.fgood, "rb") as fh:
             hdr = bytearray( fh.read(512) )
@@ -700,10 +700,11 @@ class TestEdfBadHeaderPadding(unittest.TestCase):
         im = fabio.open(self.fbytes)
         self.assertTrue( (im.data == 0).all() )
         for k in self.hdr.keys():
-            self.assertTrue( k in im.header )
-            val = im.header[k]
-            self.assertNotEqual( self.hdr[k], im.header[k] )
-            
+            if k in im.header:
+                self.assertEqual (self.hdr[k], im.header[k] )
+            else:
+                # it was one we corrupted. These are skipped for now.
+                pass
 
             
 def suite():

--- a/fabio/test/codecs/test_edfimage.py
+++ b/fabio/test/codecs/test_edfimage.py
@@ -637,76 +637,78 @@ class TestEdfIterator(unittest.TestCase):
 
 
 
-class TestEdfBadHeaderPadding(unittest.TestCase):
-    """
-    Some old data were found with headers padded with 0xcd (issue #373)
-    """
+class TestEdfBadHeader(unittest.TestCase):
+    """Test reader behavior with corrupted header file"""
+
     def setUp(self):
-        self.fgood = "TestEdfGoodHeaderPadding.edf"
-        self.fbad = "TestEdfBadHeaderPadding.edf"
-        self.fzero = "TestEdfZeroHeaderPadding.edf"
-        self.fbytes = "TestEdfBytesItem.edf"
-        self.data = numpy.zeros( (10,11), numpy.uint8 )
-        self.hdr = { "mykey"  : "myvalue", "title" : "ok" }
-        fabio.edfimage.edfimage( self.data, self.hdr ).write(self.fgood)
-        with open( self.fgood, "rb") as fh:
-            hdr = bytearray( fh.read(512) )
-            while hdr.find(b"}")<0:
+        self.fgood = os.path.join(UtilsTest.tempdir, "TestEdfGoodHeaderPadding.edf")
+        self.fbad = os.path.join(UtilsTest.tempdir, "TestEdfBadHeaderPadding.edf")
+        self.fzero = os.path.join(UtilsTest.tempdir, "TestEdfZeroHeaderPadding.edf")
+        self.fnonascii = os.path.join(UtilsTest.tempdir, "TestEdfNonAsciiItem.edf")
+        self.data = numpy.zeros((10, 11), numpy.uint8)
+        self.hdr = {"mykey": "myvalue", "title": "ok"}
+
+        good = fabio.edfimage.edfimage(self.data, self.hdr)
+        good.write(self.fgood)
+        with fabio.open(self.fgood) as good:
+            self.good_header = good.header
+
+        with open(self.fgood, "rb") as fh:
+            hdr = bytearray(fh.read(512))
+            while hdr.find(b"}") < 0:
                 hdr += fh.read(512)
             data = fh.read()
         with open( self.fbad, "wb") as fb:
-            start = hdr.rfind( b";" )+1
-            end = hdr.find(b"}")-1
-            hdr[start:end] = [ord('\n'),] + [0xcd,]*(end-start-1)
-            fb.write( hdr )
-            fb.write( data )
+            start = hdr.rfind(b";") + 1
+            end = hdr.find(b"}") - 1
+            hdr[start:end] = [ord('\n')] + [0xcd] * (end - start - 1)
+            fb.write(hdr)
+            fb.write(data)
         with open( self.fzero, "wb") as fb:
             # insert some 0x00 to be stripped
             key = b"myvalue"
             z = hdr.find(key)
-            hdr[z+len(key)] = 0
-            fb.write( hdr )
-            fb.write( data )
-        with open( self.fbytes, "wb") as fb:
-            hdr[z:z+1]=0xc3,0xa9 # e-acute in utf-8 ??
-            with open( self.fbytes, "wb") as fb:
-                fb.write( hdr )
-                fb.write( data )
+            hdr[z + len(key)] = 0
+            fb.write(hdr)
+            fb.write(data)
+        with open( self.fnonascii, "wb") as fb:
+            hdr[z:z + 1]= 0xc3, 0xa9  # e-acute in utf-8 ??
+            with open(self.fnonascii, "wb") as fb:
+                fb.write(hdr)
+                fb.write(data)
 
     def tearDown(self):
         os.remove(self.fgood)
         os.remove(self.fbad)
         os.remove(self.fzero)
+        os.remove(self.fnonascii)
 
     def testReadBadPadding(self):
-        im = fabio.open(self.fbad)
-        self.assertTrue( (im.data == 0).all() )
-        for k in self.hdr.keys():
-            self.assertEqual( self.hdr[k], im.header[k] )
+        """
+        Some old data were found with headers padded with 0xcd (issue #373)
+        """
+        with fabio.open(self.fbad) as im:
+            self.assertTrue((im.data == 0).all())
+            self.assertEqual(im.header, self.good_header)
 
     def testReadGoodPadding(self):
-        im = fabio.open(self.fgood)
-        self.assertTrue( (im.data == 0).all() )
-        for k in self.hdr.keys():
-            self.assertEqual( self.hdr[k], im.header[k] )
+        with fabio.open(self.fgood) as im:
+            self.assertTrue((im.data == 0).all())
+            self.assertEqual(im.header, self.good_header)
 
     def testReadZeroPadding(self):
-        im = fabio.open(self.fzero)
-        self.assertTrue( (im.data == 0).all() )
-        for k in self.hdr.keys():
-            self.assertEqual( self.hdr[k], im.header[k] )
+        with fabio.open(self.fzero) as im:
+            self.assertTrue((im.data == 0).all())
+            self.assertEqual(im.header, self.good_header)
 
-    def testBytesitem(self):
-        im = fabio.open(self.fbytes)
-        self.assertTrue( (im.data == 0).all() )
-        for k in self.hdr.keys():
-            if k in im.header:
-                self.assertEqual (self.hdr[k], im.header[k] )
-            else:
-                # it was one we corrupted. These are skipped for now.
-                pass
+    def testNonAsciiHeader(self):
+        """Non-ascii characters are skipped."""
+        with fabio.open(self.fnonascii) as im:
+            self.assertTrue((im.data == 0).all())
+            expected = dict(self.good_header)
+            expected.pop("mykey")
+            self.assertEqual(im.header, expected)
 
-            
 def suite():
     loadTests = unittest.defaultTestLoader.loadTestsFromTestCase
     testsuite = unittest.TestSuite()
@@ -723,7 +725,7 @@ def suite():
     testsuite.addTest(loadTests(TestBadGzFiles))
     testsuite.addTest(loadTests(TestEdfIterator))
     testsuite.addTest(loadTests(TestSphere2SaxsSamples))
-    testsuite.addTest(loadTests(TestEdfBadHeaderPadding))
+    testsuite.addTest(loadTests(TestEdfBadHeader))
     return testsuite
 
 


### PR DESCRIPTION
This PR is a clean up of #376 from @jonwright 

- warning message in case of non-ascii char in the header (in this case the key-value is drop)
- warning on duplicated key (same behavior as before, the previous key is drop)
- debug message on header line without = (not a key-value)
    - i think it would be definitely better to log it as warning

Closes #373