### PR TITLE
Remove the raise at the end of the iteration

### DIFF
--- a/fabio/fabioimage.py
+++ b/fabio/fabioimage.py
@@ -852,7 +852,7 @@ class FabioImage(_FabioArray):
             try:
                 current_image = current_image.next()
             except IOError:
-                raise StopIteration
+                break
 
 
 fabioimage = FabioImage


### PR DESCRIPTION
Here is a PR to fix #384

Considering this API was not used (cause there was this exception) i would prefer to alias if to `frames` instead of using the iteration through filenames.
```
     def __iter__(self):
        for frame in self.frames():
            yield frame
```
What do you think?