### PR TITLE
Add test for FabioImage __iter__

### DIFF
--- a/fabio/fabioimage.py
+++ b/fabio/fabioimage.py
@@ -586,6 +586,8 @@ class FabioImage(_FabioArray):
     def previous(self):
         """ returns the previous file in the series as a fabioimage """
         from .openimage import openimage
+        if self.filename is None:
+            raise IOError()
         return openimage(fabioutils.previous_filename(self.filename))
 
     def next(self):
@@ -594,6 +596,8 @@ class FabioImage(_FabioArray):
         :raise IOError: When there is no next file in the series.
         """
         from .openimage import openimage
+        if self.filename is None:
+            raise IOError()
         return openimage(
             fabioutils.next_filename(self.filename))
 

--- a/fabio/test/test_fabio_image.py
+++ b/fabio/test/test_fabio_image.py
@@ -257,9 +257,19 @@ class TestDeprecatedFabioImage(unittest.TestCase):
         image.pilimage = None
 
 
+class TestFabioImage(unittest.TestCase):
+
+    def test_iter_abort_iteration(self):
+        data = numpy.zeros((2, 2))
+        image = FabioImage(data=data)
+        for frame in image:
+            self.assertEqual(frame.data[0, 0], 0)
+
+
 def suite():
     loadTests = unittest.defaultTestLoader.loadTestsFromTestCase
     testsuite = unittest.TestSuite()
+    testsuite.addTest(loadTests(TestFabioImage))
     testsuite.addTest(loadTests(Test50000))
     testsuite.addTest(loadTests(TestSlices))
     testsuite.addTest(loadTests(TestOpen))


### PR DESCRIPTION
This PR add a test for `FabioImage.__iter__`.

That's a backport from the backport to 0.10.