### PR TITLE
Implement and test hdf5format 'next' function

### DIFF
--- a/fabio/fabioimage.py
+++ b/fabio/fabioimage.py
@@ -380,6 +380,14 @@ class FabioFrame(_FabioArray):
             return self._dtype
         return self.data.dtype
 
+    def next(self):
+        """Returns the next frame from it's file container.
+
+        :rtype: FabioFrame
+        """
+        container = self.file_container
+        return container.get_frame(self.file_index + 1)
+
 
 class FabioImage(_FabioArray):
     """A common object for images in fable

--- a/fabio/hdf5image.py
+++ b/fabio/hdf5image.py
@@ -147,8 +147,8 @@ class Hdf5Image(fabioimage.FabioImage):
         Returns a frame as a new FabioImage object
         :param num: frame number
         """
-        if num < 0 or num > self.nframes:
-            raise RuntimeError("Requested frame number %i is out of range [0, %i[ " % (num, self.nframes))
+        if num < 0 or num >= self.nframes:
+            raise IndexError("Requested frame number %i is out of range [0, %i[ " % (num, self.nframes))
         # Do a deep copy of the header to make a new one
         frame = Hdf5Frame(self, num)
         return frame

--- a/fabio/hdf5image.py
+++ b/fabio/hdf5image.py
@@ -142,6 +142,9 @@ class Hdf5Image(fabioimage.FabioImage):
             raise RuntimeError(err)
         return self
 
+    def _get_frame(self, num):
+        return self.getframe(num)
+
     def getframe(self, num):
         """
         Returns a frame as a new FabioImage object
@@ -151,6 +154,8 @@ class Hdf5Image(fabioimage.FabioImage):
             raise IndexError("Requested frame number %i is out of range [0, %i[ " % (num, self.nframes))
         # Do a deep copy of the header to make a new one
         frame = Hdf5Frame(self, num)
+        frame._set_container(self, num)
+        frame._set_file_container(self, num)
         return frame
 
     def next(self):

--- a/fabio/test/codecs/test_hdf5image.py
+++ b/fabio/test/codecs/test_hdf5image.py
@@ -99,6 +99,22 @@ class TestHdf5(unittest.TestCase):
         self.assertEqual(e.nframes, 50, "nframes OK")
         self.assertEqual(e.bpp, 4, "nframes OK")
 
+    def test_next_frames(self):
+        """ check the legacy next API"""
+        h5 = openimage(self.fn3)
+        frame_nb = 1
+        frame_id = 0
+        frame = h5
+        while True:
+            try:
+                frame = frame.next()
+                frame_id = frame.file_index
+                frame_nb += 1
+            except IndexError:
+                break
+        self.assertEqual(frame_nb, 50)
+        self.assertEqual(frame_id, 49)
+
 
 def suite():
     loadTests = unittest.defaultTestLoader.loadTestsFromTestCase


### PR DESCRIPTION
This PR implements the `next` function to HDF5 frames.

Limitation: As the link between frame to container is a weakref, the reference to the fabioimage have to be referenced by the user.

Closes #397 