### PR TITLE
Change README section order and reformulate some paragraphs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -14,21 +14,64 @@ Main websites:
 FabIO is an I/O library for images produced by 2D X-ray detectors and written in Python.
 FabIO support images detectors from a dozen of companies (including Mar, Dectris, ADSC, Hamamatsu, Oxford, ...),
 for a total of 30 different file formats (like CBF, EDF, TIFF, ...) and offers an unified interface to their
-headers (as a python dictionary) and datasets (as a numpy ndarray of integers or floats)
+headers (as a Python dictionary) and datasets (as a numpy ndarray of integers or floats)
 
-Getting FabIO
--------------
 
-FabIO is available from `PyPI <https://pypi.python.org/pypi/fabio>`_.
+.. contents::
+    :depth: 1
+
+Installation
+------------
+
+FabIO is available from `PyPI <https://pypi.python.org/pypi/fabio>`_:
+
+``pip install fabio``
+
 
 `Debian/Ubuntu packages <http://www.silx.org/pub/debian/binary/>`_, and
 `wheels <http://www.silx.org/pub/wheelhouse/>`_ are available
-for windows, linux and MacOSX from the silx repository:
+for Windows, Linux and MacOSX from the silx repository. 
 
-Documentation is available at `silx <http://www.silx.org/doc/fabio/>`_. 
+See the `installation instructions <http://www.silx.org/doc/fabio/latest/Installation.html>`_ for more information.
 
-Citation:
+Usage
+-----
+
+Open an image
+.............
+
+  >>> import fabio
+  >>> obj = fabio.open("mydata0000.edf")
+  >>> obj.data.shape
+  (2048, 2048)
+  >>> obj.header["Omega"]
+  23.5
+  >>> obj.data
+  array([...])
+
+Save an image (ex: EDF)
+.......................
+
+  >>> import fabio
+  >>> obj = fabio.edfimage.EdfImage(data=[...])
+  >>> obj.write("mydata0000.edf")
+
+
+Documentation
+-------------
+
+See the `latest release documentation <http://www.silx.org/doc/fabio/latest/>`_ for further details.
+
+Documentation of previous versions are available on `silx <http://www.silx.org/doc/fabio/>`_.
+
+Changelog
 ---------
+
+See http://www.silx.org/doc/fabio/latest/Changelog.html
+
+
+Citation
+--------
 
 The general philosophy of the library is described in:
 `FabIO: easy access to two-dimensional X-ray detector images in Python; E. B. Knudsen, H. O. Sørensen, J. P. Wright, G. Goret and J. Kieffer Journal of Applied Crystallography, Volume 46, Part 2, pages 537-539. <http://dx.doi.org/10.1107/S0021889813000150>`_
@@ -36,75 +79,10 @@ The general philosophy of the library is described in:
 Transparent handling of compressed files
 ----------------------------------------
 
-FabIO is expected to handle gzip and bzip2 compressed files transparently.
-Following a query about the performance of reading compressed data, some
-benchmarking details have been collected at fabio_compressed_speed.
-This means that when your python was configured and built you needed the
-bzip and gzip modules to be present (eg libbz2-dev package for ubuntu)
-Using fabio in your own python programs
-Example::
+For FabIO to handle gzip and bzip2 compressed files transparently, ``bzip`` and ``gzip`` modules must be present when installing/building Python (e.g. ``libbz2-dev`` package for Ubuntu).
 
-  >>> import fabio
-  >>> obj = fabio.edfimage.EdfImage("mydata0000.edf")
-  >>> obj.data.shape
-  (2048, 2048)
-  >>> obj.header["Omega"]
-  23.5
+Benchmarking details have been collected at http://www.silx.org/doc/fabio/latest/performances.html.
 
-
-Design Specifications
----------------------
-
-Name: 
-.....
-
-FabIO = Fable Input/Output
-
-Idea:
-.....
-
-Have a base class for all our 2D diffraction greyscale images.
-This consists of a 2D array (numpy ndarray)
-and a python dictionary (actually an ordered dict) of header information in (string key, string value) pairs.
-
-Class FabioImage
-................
-
-Needs a name which will not to be confused with an RGB color image.
-
-Class attributes, often exposed as properties:
-
-* data   					-> 2D array
-* header 					-> ordered dictionary
-* rows, columns, dim1, dim2 -> data.shape (propertiy)
-* header_keys               -> property for list(header.keys()), formerly used to retain the order of the header
-* bytecode                 	-> data.typecode() (property)
-* m, minval, maxval, stddev	-> image statistics, could add others, eg roi[slice]
-
-Class methods (functions):
-
-* integrate_area()      -> return sum(self.data) within slice
-* rebin(fact)           -> rebins data, adjusts dims
-* toPIL16()             -> returns a PILimage
-* getheader()           -> returns self.header
-* resetvals()           -> resets the statistics
-* getmean()             -> (computes) returns self.m
-* getmin()              -> (computes) returns self.minval
-* getmax()              -> (computes) returns self.maxval
-* getstddev()           -> (computes) returns self.stddev
-* read()        		-> read image from file [or stream, or shared memory]
-* write()       		-> write image to file  [or stream, or shared memory]
-* readheader()          -> read only the header [much faster for scanning files]
-
-Each individual file format would then inherit all the functionality of this class and just make new read and write methods.
-
-There are also fileseries related methods (next(), previous(), ...) which returns a FabioImage instance of the next/previous frame in a fileserie
-
-Other feature:
-
-* possibility for using on-the-fly external compression - i.e. if files are
-  stored as something as .gz, .bz2 etc could decompress them, using an external
-  compression mechanism (if available). 
 
 
 Supported file formats
@@ -212,15 +190,62 @@ Supported file formats
   	- TiffIO taken from PyMca
 
 
-Installation
-------------
 
-Please see doc/source/INSTALL.rst
+Design Specifications
+---------------------
 
-Changelog
----------
+Name: 
+.....
 
-Please see doc/source/Changelog.rst
+FabIO = Fable Input/Output
+
+Idea:
+.....
+
+Have a base class for all our 2D diffraction greyscale images.
+This consists of a 2D array (numpy ndarray)
+and a python dictionary (actually an ordered dict) of header information in (string key, string value) pairs.
+
+Class FabioImage
+................
+
+Needs a name which will not to be confused with an RGB color image.
+
+Class attributes, often exposed as properties:
+
+* data   					-> 2D array
+* header 					-> ordered dictionary
+* rows, columns, dim1, dim2 -> data.shape (propertiy)
+* header_keys               -> property for list(header.keys()), formerly used to retain the order of the header
+* bytecode                 	-> data.typecode() (property)
+* m, minval, maxval, stddev	-> image statistics, could add others, eg roi[slice]
+
+Class methods (functions):
+
+* integrate_area()      -> return sum(self.data) within slice
+* rebin(fact)           -> rebins data, adjusts dims
+* toPIL16()             -> returns a PILimage
+* getheader()           -> returns self.header
+* resetvals()           -> resets the statistics
+* getmean()             -> (computes) returns self.m
+* getmin()              -> (computes) returns self.minval
+* getmax()              -> (computes) returns self.maxval
+* getstddev()           -> (computes) returns self.stddev
+* read()        		-> read image from file [or stream, or shared memory]
+* write()       		-> write image to file  [or stream, or shared memory]
+* readheader()          -> read only the header [much faster for scanning files]
+
+Each individual file format would then inherit all the functionality of this class and just make new read and write methods.
+
+There are also fileseries related methods (next(), previous(), ...) which returns a FabioImage instance of the next/previous frame in a fileserie
+
+Other feature:
+
+* possibility for using on-the-fly external compression - i.e. if files are
+  stored as something as .gz, .bz2 etc could decompress them, using an external
+  compression mechanism (if available). 
+
+
 
 .. |Build Status| image:: https://travis-ci.org/silx-kit/fabio.svg?branch=master
    :target: https://travis-ci.org/silx-kit/fabio


### PR DESCRIPTION
Fix #455 

- Changed order of sections to put forward **Installation**, **Usage** and **Documentation**
- Updated **Usage** examples
- Added a table of contents
- Reformulated **Transparent handling of compressed files** section (was really hard to understand). Please review to see if the sense is still correct.
- **Installation** and **Changelog** links point now to the online doc

I left **Design Specifications** untouched but in my opinion, it should be in the online doc and not in the README.