### PR TITLE
12 bit data is no longer assumed 

### DIFF
--- a/fabio/HiPiCimage.py
+++ b/fabio/HiPiCimage.py
@@ -58,7 +58,7 @@ class HipicImage(FabioImage):
         Read in a header from an already open file
 
         """
-        Image_tag = infile.read(2)
+        Image_tag = infile.read(2).decode()
         Comment_len = numpy.frombuffer(infile.read(2), numpy.uint16)
         Dim_1 = numpy.frombuffer(infile.read(2), numpy.uint16)[0]
         Dim_2 = numpy.frombuffer(infile.read(2), numpy.uint16)[0]
@@ -66,7 +66,8 @@ class HipicImage(FabioImage):
         Dim_2_offset = numpy.frombuffer(infile.read(2), numpy.uint16)[0]
         _HeaderType = numpy.frombuffer(infile.read(2), numpy.uint16)[0]
         _Dump = infile.read(50)
-        Comment = infile.read(Comment_len)
+        Comment = infile.read(Comment_len[0])
+        Comment = Comment.decode()
         self.header['Image_tag'] = Image_tag
         self.header['Dim_1'] = Dim_1
         self.header['Dim_2'] = Dim_2

--- a/fabio/HiPiCimage.py
+++ b/fabio/HiPiCimage.py
@@ -124,13 +124,19 @@ class HipicImage(FabioImage):
         self._dtype = None
         self._shape = None
 
-        # Sometimes these files are not saved as 12 bit,
-        # But as 16 bit after bg subtraction - which results
-        # negative values saved as 16bit. Therefore values higher
-        # 4095 is really negative values
-        if self.data.max() > 4095:
-            gt12bit = self.data > 4095
-            self.data = self.data - gt12bit * (2 ** 16 - 1)
+
+        #### The case below is not true for data collected at 
+        #### BL47XU/BL20XU/BL20B at SPring-8 - here the data is saved as 
+        #### 16 bit - so values above 4095 should be negative.
+        #### Therefore I have now commented it out.
+        
+        # # Sometimes these files are not saved as 12 bit,
+        # # But as 16 bit after bg subtraction - which results
+        # # negative values saved as 16bit. Therefore values higher
+        # # 4095 is really negative values
+        # if self.data.max() > 4095:
+        #     gt12bit = self.data > 4095
+        #     self.data = self.data - gt12bit * (2 ** 16 - 1)
         return self
 
 


### PR DESCRIPTION
The assumption that data from HiPic is 12 bit data so if values are able 4095 it is a BG corrected image and these values should be negative, has been removed.