### PR TITLE
[IO] Ignore photometric interpretation if not supported.

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.7', '3.8', '3.9', '3.10']
 
     steps:
     - uses: actions/checkout@v2

--- a/fabio/TiffIO.py
+++ b/fabio/TiffIO.py
@@ -1,6 +1,6 @@
 # The PyMca X-Ray Fluorescence Toolkit
 #
-# Copyright (c) 2004-2020 European Synchrotron Radiation Facility
+# Copyright (c) 2004-2022 European Synchrotron Radiation Facility
 #
 # This file is part of the PyMca X-ray Fluorescence Toolkit developed at
 # the ESRF by the Software group.
@@ -23,11 +23,11 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-__author__ = "V.A. Sole - ESRF Data Analysis"
+__author__ = "V.A. Sole - ESRF"
 __contact__ = "sole@esrf.fr"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
-__date__ = "26/12/2020"
+__date__ = "29/12/2022"
 
 import sys
 import os
@@ -591,7 +591,7 @@ class TiffIO(object):
             # raise IOError("Palette-color Image. Only grayscale images supported")
         elif interpretation > 2:
             # Palette Color Image
-            raise IOError("Only grayscale images supported")
+            logger.warning("Only grayscale and RGB images supported")
 
         nRows = info["nRows"]
         nColumns = info["nColumns"]


### PR DESCRIPTION
To try to workaround #502 