### PR TITLE
Signed floats cbf

### DIFF
--- a/src/fabio/cbfimage.py
+++ b/src/fabio/cbfimage.py
@@ -62,6 +62,8 @@ DATA_TYPES = {"signed 8-bit integer": "int8",
               "unsigned 16-bit integer": "uint16",
               "unsigned 32-bit integer": "uint32",
               "unsigned 64-bit integer": "uint64"
+              "signed 32-bit real IEEE": "float"
+              "signed 64-bit real IEEE": "double"
               }
 
 MINIMUM_KEYS = ["X-Binary-Size-Fastest-Dimension",

--- a/src/fabio/cbfimage.py
+++ b/src/fabio/cbfimage.py
@@ -61,8 +61,8 @@ DATA_TYPES = {"signed 8-bit integer": "int8",
               "unsigned 8-bit integer": "uint8",
               "unsigned 16-bit integer": "uint16",
               "unsigned 32-bit integer": "uint32",
-              "unsigned 64-bit integer": "uint64"
-              "signed 32-bit real IEEE": "float"
+              "unsigned 64-bit integer": "uint64",
+              "signed 32-bit real IEEE": "float",
               "signed 64-bit real IEEE": "double"
               }
 


### PR DESCRIPTION
Currently, FabIO does not recognize signed floats as valid data type for .cbf files, only integers. However, floats are a legitimate possibility for the CBF standard, so I have added two lines to DATA_TYPES to accommodate this.