### PR TITLE
Add support for GE files with an EDF header

### DIFF
--- a/src/fabio/openimage.py
+++ b/src/fabio/openimage.py
@@ -151,7 +151,7 @@ def do_magic(byts, filename):
                     else:
                         return "tif"
 
-            if format_type == "edf":
+            if format_type == "edf" and isinstance(filename, str):
                 # Might be GE with an EDF header
                 # If the extension is `ge` plus a number, assume it is GE
                 extension = filename.split(".")[-1]

--- a/src/fabio/openimage.py
+++ b/src/fabio/openimage.py
@@ -44,6 +44,7 @@ import os.path
 import logging
 import re
 from . import fabioutils
+from .compression import ExternalCompressors
 from .fabioutils import FilenameObject, BytesIO
 from .fabioimage import FabioImage
 
@@ -152,9 +153,13 @@ def do_magic(byts, filename):
                         return "tif"
 
             if format_type == "edf" and isinstance(filename, str):
-                # Might be GE with an EDF header
-                # If the extension is `ge` plus a number, assume it is GE
+                # Might be GE with an EDF header. Check the extension.
                 extension = filename.split(".")[-1]
+                # If it is a compression extension, check the next one up.
+                if f'.{extension}' in ExternalCompressors.COMMANDS:
+                    extension = filename.split(".")[-2]
+
+                # If the extension is `ge` plus a number, assume it is GE
                 if re.search(r'^ge\d*$', extension):
                     return "GE"
 

--- a/src/fabio/openimage.py
+++ b/src/fabio/openimage.py
@@ -42,6 +42,7 @@ mods for APS GE by JVB
 
 import os.path
 import logging
+import re
 from . import fabioutils
 from .fabioutils import FilenameObject, BytesIO
 from .fabioimage import FabioImage
@@ -149,6 +150,14 @@ def do_magic(byts, filename):
                         return "marccd"
                     else:
                         return "tif"
+
+            if format_type == "edf":
+                # Might be GE with an EDF header
+                # If the extension is `ge` plus a number, assume it is GE
+                extension = filename.split(".")[-1]
+                if re.search(r'^ge\d*$', extension):
+                    return "GE"
+
             return format_type
     raise Exception("Could not interpret magic string")
 

--- a/src/fabio/test/codecs/test_geimage.py
+++ b/src/fabio/test/codecs/test_geimage.py
@@ -53,6 +53,7 @@ class TestGE(unittest.TestCase):
         ("GE_aSI_detector_image_1529", (2048, 2048), (1515, 16353, 1833.0311, 56.9124)),
         ("GE_image_1frame_intact_header.ge", (2048, 2048), (1515, 16353, 2209.1113, 437.6377)),
         ("GE_image_1frame_blanked_header.ge", (2048, 2048), (1300, 16349, 1886.41111, 117.0603)),
+        ("dark_before_000428.edf.ge5", (2048, 2048), (1300, 16349, 1833.87892, 84.5265)),
     ]
 
     def setUp(self):


### PR DESCRIPTION
This file type started coming from APS in ~2022 with a `.edf.ge5` extension.

In fabio, these were being interpreted as EDF files because of their EDF-like header. With the changes in this PR, the file is interpreted as a GE file instead and the frames are read in correctly.

The added logic is as follows:

1. If the file is identified as EDF, we check the file extension, and if the file extension is `ge` plus a number, it is interpreted as GE instead.
2. We check for EDF header formats in the GE reader, and if we have a match, we read in the header using EDF style and grab the number of frames from there.

I have an ~80 MB dark example... let me see if we can make that public for testing.

Fixes: #553