### PR TITLE
CI: Added github action release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,135 @@
+name: Build and deploy
+
+on:
+  workflow_dispatch:
+  release:
+    types:
+      - published
+
+jobs:
+  build_sdist:
+    name: Build source distribution
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: "pip"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install build twine
+      - name: Build sdist
+        run: python -m build --sdist
+      - name: Check the package
+        run: python -m twine check dist/*
+      - uses: actions/upload-artifact@v4
+        with:
+          name: cibw-sdist
+          path: dist/*.tar.gz
+
+  test_sdist:
+    needs: [build_sdist]
+    name: Test source distribution
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: "pip"
+      - uses: actions/download-artifact@v4
+        with:
+          name: cibw-sdist
+          path: dist
+      - name: Install from sdist
+        run: pip install "$(ls dist/fabio-*.tar.gz)"
+      - name: Run tests
+        run: python -c "import fabio.test, sys; sys.exit(fabio.test.run_tests())"
+
+  build_doc:
+    name: Build documentation
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: "pip"
+      - name: Install fabio
+        run: |
+          pip install .
+      - name: Build doc
+        run: |
+          export FABIO_VERSION="$(python -c 'import fabio; print(fabio.strictversion)')"
+          sphinx-build doc/source/ "fabio-${FABIO_VERSION}_documentation/"
+          zip -r "fabio-${FABIO_VERSION}_documentation.zip" "fabio-${FABIO_VERSION}_documentation/"
+      - uses: actions/upload-artifact@v4
+        with:
+          name: documentation
+          path: fabio-*_documentation.zip
+
+  build_wheels:
+    name: Build wheels on ${{ matrix.os }}-${{ matrix.cibw_archs }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      # Ensure that a wheel builder finishes even if another fails
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-20.04
+            cibw_archs: "auto64"
+          - os: ubuntu-20.04
+            cibw_archs: "aarch64"
+          - os: ubuntu-20.04
+            cibw_archs: "ppc64le"
+          - os: windows-2019
+            cibw_archs: "auto64"
+          - os: macos-11
+            cibw_archs: "universal2"
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-qemu-action@v3
+        if: runner.os == 'Linux'
+        with:
+          platforms: all
+      - uses: pypa/cibuildwheel@v2.16.5
+        env:
+          # Use silx wheelhouse: needed for ppc64le
+          CIBW_ENVIRONMENT_LINUX: "PIP_FIND_LINKS=https://www.silx.org/pub/wheelhouse/ PIP_TRUSTED_HOST=www.silx.org"
+
+          CIBW_BUILD: cp37-* cp38-* cp39-* cp310-* cp311-* cp312-*
+          # Do not build for pypy and muslinux
+          CIBW_SKIP: pp* *-musllinux_*
+          CIBW_ARCHS: ${{ matrix.cibw_archs }}
+
+          # Install test dependencies
+          CIBW_TEST_COMMAND: python -c "import fabio.test, sys; sys.exit(fabio.test.run_tests())"
+          # Skip tests for emulated architectures and arm64 macos
+          CIBW_TEST_SKIP: "*-*linux_{aarch64,ppc64le,s390x} *-macosx_arm64 *-macosx_universal2:arm64"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: cibw-wheels-${{ matrix.os }}-${{ strategy.job-index }}
+          path: ./wheelhouse/*.whl
+
+  pypi-publish:
+    needs: [build_doc, build_sdist, build_wheels, test_sdist]
+    name: Upload release to PyPI
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+    permissions:
+      id-token: write
+    if: github.event_name == 'release' && github.event.action == 'published'
+    # or, alternatively, upload to PyPI on every tag starting with 'v' (remove on: release above to use this)
+    # if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: cibw-*
+          path: dist
+          merge-multiple: true
+      - uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,9 +58,12 @@ jobs:
           python-version: "3.12"
           cache: "pip"
       - name: Install fabio
-        run: |
-          pip install .
+        run: pip install .
+      - name: Install documentation dependencies
+        run: pip install -r requirements.txt
       - name: Build doc
+        env:
+          READTHEDOCS: "True"  # To skip checking that fabio is installed locally
         run: |
           export FABIO_VERSION="$(python -c 'import fabio; print(fabio.strictversion)')"
           sphinx-build doc/source/ "fabio-${FABIO_VERSION}_documentation/"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,7 +90,11 @@ jobs:
           - os: windows-2019
             cibw_archs: "auto64"
           - os: macos-11
-            cibw_archs: "universal2"
+            cibw_archs: "x86_64"
+            macos_target: "10.9"
+          - os: macos-14
+            cibw_archs: "arm64"
+            macos_target: "11.0"
 
     steps:
       - uses: actions/checkout@v4
@@ -108,10 +112,12 @@ jobs:
           CIBW_SKIP: pp* *-musllinux_*
           CIBW_ARCHS: ${{ matrix.cibw_archs }}
 
+          MACOSX_DEPLOYMENT_TARGET: "${{ matrix.macos_target }}"
+
           # Install test dependencies
           CIBW_TEST_COMMAND: python -c "import fabio.test, sys; sys.exit(fabio.test.run_tests())"
-          # Skip tests for emulated architectures and arm64 macos
-          CIBW_TEST_SKIP: "*-*linux_{aarch64,ppc64le,s390x} *-macosx_arm64 *-macosx_universal2:arm64"
+          # Skip tests for emulated architectures
+          CIBW_TEST_SKIP: "*-*linux_{aarch64,ppc64le,s390x}"
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -119,7 +119,8 @@ jobs:
           # Install test dependencies
           CIBW_TEST_COMMAND: python -c "import fabio.test, sys; sys.exit(fabio.test.run_tests())"
           # Skip tests for emulated architectures
-          CIBW_TEST_SKIP: "*-*linux_{aarch64,ppc64le,s390x}"
+          # and Python3.8 on macos/arm64 (https://github.com/pypa/cibuildwheel/pull/1169)
+          CIBW_TEST_SKIP: "*-*linux_{aarch64,ppc64le,s390x} cp38-macosx_arm64"
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,6 +57,8 @@ jobs:
         with:
           python-version: "3.12"
           cache: "pip"
+      - name: Install pandoc&graphviz
+        run: sudo apt-get install pandoc graphviz
       - name: Install fabio
         run: pip install .
       - name: Install documentation dependencies

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -13,10 +13,7 @@
 
 import sys
 import os
-import glob
-import subprocess
 
-on_rtd = os.environ.get('READTHEDOCS') == 'True'
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
@@ -26,7 +23,7 @@ try:
     import fabio
     project_dir = os.path.abspath(os.path.join(__file__, "..", "..", ".."))
     build_dir = os.path.abspath(fabio.__file__)
-    if on_rtd:
+    if os.environ.get('READTHEDOCS') == 'True':
         print("On Read The Docs")
         print("build_dir", build_dir)
         print("project_dir", project_dir)
@@ -55,18 +52,10 @@ except:
 
 extensions = ['sphinx.ext.autodoc',
               'sphinx.ext.mathjax',
+              'sphinx_rtd_theme',
               'sphinxcontrib.programoutput',
               'nbsphinx'
               ]
-
-# Set the theme to sphinx_rtd_theme when *not* building on Read The Docs.
-# The theme is set to default otherwise as Read The Docs uses its own theme anyway.
-if not on_rtd:
-    try:
-        import sphinx_rtd_theme
-        extensions.append('sphinx_rtd_theme')
-    except:
-        print("sphinx_rtd_theme is not available")
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
@@ -81,7 +70,7 @@ source_suffix = '.rst'
 master_doc = 'index'
 
 # General information about the project.
-from fabio.version import strictversion, version, __date__ as fabio_date
+from fabio.version import strictversion, __date__ as fabio_date
 
 year = fabio_date.split("/")[-1]
 copyright = u'2006-%s, Henning Sorensen, Erik Knudsen, Jon Wright, Gael Goret, Brian Pauw and Jerome Kieffer' % (year)
@@ -136,7 +125,7 @@ pygments_style = 'sphinx'
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme = 'default' if on_rtd else 'sphinx_rtd_theme'
+html_theme = 'sphinx_rtd_theme'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,8 +55,6 @@ requires = [
     'ninja',
     'wheel',
     'Cython>=0.29',
-    "numpy<1.26.0; platform_machine == 'ppc64le'",
-    "numpy; platform_machine != 'ppc64le'",
     'pyproject-metadata>=0.5.0',
     'tomli>=1.0.0'
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ hdf5plugin
 sphinx
 sphinxcontrib-programoutput
 sphinx-rtd-theme
+nbsphinx


### PR DESCRIPTION
This PR adds a release workflow that is triggered when publishing a release in github and that can be run manually.

This workflow:
- Builds and tests the source tarball
- Builds and tests the wheels with cibuildwheel
- Builds the documentation and saves it as a zip file
- Publishes the tarball and wheels in pypi when the workflow is triggered by a published release (and after validation)

To make it work it requires to:
- [x] Create an environment in github
- [x] [Add a publisher to pypi](https://docs.pypi.org/trusted-publishers/adding-a-publisher/)

This is adapted from cibuildwheel documentation:
- [Configure a CI service](https://cibuildwheel.pypa.io/en/stable/setup/#github-actions)
- [Deliver to pypi](https://cibuildwheel.pypa.io/en/stable/deliver-to-pypi/#github-actions)

It's similar to [silx's release.yml](https://github.com/silx-kit/silx/blob/main/.github/workflows/release.yml) and [hdf5plugin's release.yml](https://github.com/silx-kit/hdf5plugin/blob/main/.github/workflows/release.yml)
