### PR TITLE
Issues spotted by debian report

### DIFF
--- a/build-deb.sh
+++ b/build-deb.sh
@@ -171,9 +171,15 @@ build_deb() {
     echo "Build for debian 9 or newer using actual packaging"
     tarname=${project}_${debianversion}.orig.tar.gz
     clean_up
-    python -m build -s
-    ln -s ${source_project}-${strictversion}.tar.gz dist/${tarname}
-    directory=${source_project}-${strictversion}
+    if [ $debian_version -le 11 ]
+    then
+       python3 setup.py debian_src
+       directory=${project}-${strictversion}
+    else
+       python3 -m build -s
+       ln -s ${source_project}-${strictversion}.tar.gz dist/${tarname}
+       directory=${source_project}-${strictversion}
+    fi
     cp -f dist/${tarname} ${build_directory}
     if [ -f dist/${project}-testimages.tar.gz ]
     then
@@ -236,10 +242,13 @@ build_deb() {
         11)
             debian_name=bullseye
             ;;
+        12)
+            debian_name=bookworm
+            ;;
     esac
 
-    dch -v ${debianversion}-1 "upstream development build of ${project} ${version}" --force-distribution
-    dch -D ${debian_name}-backports -l~bpo${debian_version}+ "${project} snapshot ${version} built for ${target_system}" --force-distribution
+    dch --force-distribution -v ${debianversion}-1 "upstream development build of ${project} ${version}"
+    dch --force-distribution -D ${debian_name}-backports -l~bpo${debian_version}+ "${project} snapshot ${version} built for ${target_system}"
     #dch --bpo "${project} snapshot ${version} built for ${target_system}"
     dpkg-buildpackage -r
     rc=$?

--- a/src/fabio/compression/agi_bitfield.py
+++ b/src/fabio/compression/agi_bitfield.py
@@ -39,7 +39,7 @@ Inspired by C++ code:   https://git.3lp.cx/dyadkin/cryio/src/branch/master/src/e
 __author__ = ["Florian Plaswig", "Jérôme Kieffer"]
 __contact__ = "jerome.kieffer@esrf.eu"
 __license__ = "MIT"
-__date__ = "13/11/2020"
+__date__ = "30/05/2024"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
 
 import logging
@@ -79,7 +79,7 @@ def compress(frame):
     if numpy.little_endian:
         buffer.write(row_start.tobytes())
     else:
-        buffer.write(row_start.byteswap.tobytes())
+        buffer.write(row_start.byteswap().tobytes())
 
     return data_size + buffer.getvalue()
 

--- a/src/fabio/dm3image.py
+++ b/src/fabio/dm3image.py
@@ -37,7 +37,7 @@ Authors: Henning O. Sorensen & Erik Knudsen
 
         + Jon Wright, ESRF
 """
-
+import sys
 import logging
 import numpy
 from .fabioimage import FabioImage
@@ -93,11 +93,12 @@ class Dm3Image(FabioImage):
         self.tag_label_length = None
 
     def _readheader(self):
+        BE_uint32 = numpy.dtype('>u4')
         self.infile.seek(0)
-        file_format = self.readbytes(4, numpy.uint32)[0]  # should be 3
-        assert file_format == 3, 'Wrong file type '
-        self.bytes_in_file = self.readbytes(4, numpy.uint32)[0]
-        self.byte_order = self.readbytes(4, numpy.uint32)[0]  # 0 = big, 1= little
+        file_format = self.readbytes(4, BE_uint32, swap=False)[0]  # should be 3
+        assert file_format == 3, 'Wrong file type'
+        self.bytes_in_file = self.readbytes(4, BE_uint32, swap=False)[0]
+        self.byte_order = self.readbytes(4, BE_uint32, swap=False)[0]  # 0 = big, 1= little
         logger.debug('read dm3 file - file format %s' % file_format)
         logger.debug('Bytes in file: %s' % self.bytes_in_file)
         logger.debug('Byte order: %s  - 0 = bigEndian , 1 = littleEndian' % self.byte_order)

--- a/src/fabio/ext/src/columnfile.c
+++ b/src/fabio/ext/src/columnfile.c
@@ -193,11 +193,11 @@ void *cf_read_ascii(void *fp, void *dest, unsigned int FLAGS){/*{{{*/
     if ((gzgets((gzFile )fp,line,2048))==Z_NULL) {fprintf(stderr,"zlib io error reading file at %s\n",__LINE__);return -1;}
     if(gzeof((gzFile)fp)) break;
   }else{
-    fgets(line,2048,(FILE *)fp);
+    if fgets(line,2048,(FILE *)fp) == NULL) break;
     if (feof((FILE *)fp)) break;
   }
 #else
-  fgets(line,2048,(FILE *)fp);
+  if (fgets(line,2048,(FILE *)fp) == NULL) break;
   if (feof((FILE *)fp)) break;
 #endif
 

--- a/src/fabio/fit2dmaskimage.py
+++ b/src/fabio/fit2dmaskimage.py
@@ -65,10 +65,8 @@ class Fit2dMaskImage(FabioImage):
                      (b"K", 12)]:
             if header[j] != i[0]:
                 raise Exception("Not a fit2d mask file")
-        fit2dhdr = numpy.frombuffer(header, numpy.int32)
         # Enforce little endian
-        if not numpy.little_endian:
-            fit2dhdr.byteswap(True)
+        fit2dhdr = numpy.frombuffer(header, numpy.dtype("<i4"))
         dim1 = fit2dhdr[4]  # 1 less than Andy's fortran
         dim2 = fit2dhdr[5]
         self._shape = dim2, dim1

--- a/src/fabio/pixiimage.py
+++ b/src/fabio/pixiimage.py
@@ -37,7 +37,7 @@ __authors__ = ["Jon Wright", "Jérôme Kieffer"]
 __contact__ = "wright@esrf.fr"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
-__date__ = "03/04/2020"
+__date__ = "30/05/2024"
 
 import numpy
 import os
@@ -71,7 +71,7 @@ class PixiImage(fabioimage.FabioImage):
         infile.seek(0)
         self.header = self.check_header()
         byt = infile.read(4)
-        framesize = numpy.frombuffer(byt, numpy.int32)
+        framesize = numpy.frombuffer(byt, numpy.dtype("<i4"))
         if framesize * 2 == self._FRAME_SIZE - self._MAGIC_SIZE:
             self.header['framesize'] = framesize
             self.header['width'] = self._IMAGE_WIDTH
@@ -123,7 +123,7 @@ class PixiImage(fabioimage.FabioImage):
         imgstart = self.header['offset'] + img_num * self._FRAME_SIZE
         filepointer.seek(imgstart, 0)
         data = numpy.frombuffer(filepointer.read(self._IMAGE_SIZE),
-                                numpy.uint16).copy()
+                                numpy.dtype("<u2")).copy()
         data.shape = self.header['height'], self.header['width']
         return data
 

--- a/src/fabio/test/codecs/test_binaryimage.py
+++ b/src/fabio/test/codecs/test_binaryimage.py
@@ -64,18 +64,16 @@ class TestBinaryImage(unittest.TestCase):
         self.assertEqual(e.shape, f.shape)
         self.assertEqual(e.bpp, f.bpp, "bpp OK")
         print(self.fn3)
-        self.assertEqual(abs(e.data-f.data).max(), 0, "data OK")
-        
-
+        self.assertEqual(abs(e.data - f.data).max(), 0, "data OK")
 
     def test_write(self):
         fn = os.path.join(UtilsTest.tempdir, "binary_write.h5")
         ary = numpy.random.randint(0, 100, size=self.shape)
-        e = BinaryImage(data = ary)
+        e = BinaryImage(data=ary)
         e.save(fn)
         self.assertTrue(os.path.exists(fn), "file exists")
         f = BinaryImage()
-        f.read(fn, self.shape[1], self.shape[0], offset=0, bytecode=ary.dtype)
+        f.read(fn, self.shape[1], self.shape[0], offset=0, bytecode=ary.dtype, endian=ary.dtype.str[0])
         self.assertEqual(str(f.__class__.__name__), "BinaryImage", "Used the write reader")
         self.assertEqual(self.shape, f.shape, "shape matches")
         self.assertEqual(abs(f.data - ary).max(), 0, "first frame matches")

--- a/src/fabio/test/test_fabio_image.py
+++ b/src/fabio/test/test_fabio_image.py
@@ -231,9 +231,9 @@ class TestPilImage2(TestPilImage):
     def mkdata(self, shape, typ):
         """ positive and big"""
         if numpy.issubdtype(typ, numpy.integer):
-            maxi = numpy.iinfo(typ).max()
+            maxi = numpy.iinfo(typ).max
         else:
-            maxi = numpy.iinfo(numpy.integer).max()
+            maxi = numpy.iinfo(numpy.integer).max
         return (numpy.random.random(shape) * maxi / 10).astype(typ)
 
 
@@ -243,9 +243,9 @@ class TestPilImage3(TestPilImage):
     def mkdata(self, shape, typ):
         """ positive, negative and big"""
         if numpy.issubdtype(typ, numpy.integer):
-            maxi = numpy.iinfo(typ).max()
+            maxi = numpy.iinfo(typ).max
         else:
-            maxi = numpy.iinfo(numpy.integer).max()
+            maxi = numpy.iinfo(numpy.integer).max
         return ((numpy.random.random(shape) - 0.5) * maxi / 10).astype(typ)
 
 

--- a/src/fabio/test/test_fabio_image.py
+++ b/src/fabio/test/test_fabio_image.py
@@ -33,6 +33,7 @@ import os
 import numpy
 import copy
 import logging
+import numbers
 
 logger = logging.getLogger(__name__)
 
@@ -229,7 +230,11 @@ class TestPilImage2(TestPilImage):
 
     def mkdata(self, shape, typ):
         """ positive and big"""
-        return (numpy.random.random(shape) * sys.maxsize / 10).astype(typ)
+        if numpy.issubdtype(typ, numpy.integer):
+            maxi = numpy.iinfo(typ).max()
+        else:
+            maxi = numpy.iinfo(numpy.integer).max()
+        return (numpy.random.random(shape) * maxi / 10).astype(typ)
 
 
 class TestPilImage3(TestPilImage):
@@ -237,7 +242,11 @@ class TestPilImage3(TestPilImage):
 
     def mkdata(self, shape, typ):
         """ positive, negative and big"""
-        return ((numpy.random.random(shape) - 0.5) * sys.maxsize / 10).astype(typ)
+        if numpy.issubdtype(typ, numpy.integer):
+            maxi = numpy.iinfo(typ).max()
+        else:
+            maxi = numpy.iinfo(numpy.integer).max()
+        return ((numpy.random.random(shape) - 0.5) * maxi / 10).astype(typ)
 
 
 class TestDeprecatedFabioImage(unittest.TestCase):


### PR DESCRIPTION
Close #571 
close #570 
* [X] overflow during numpy cast (warning)
* [X] `fgets` return value unused (warning)
* [x]  `fabio.test.codecs.test_binaryimage.TestBinaryImage.test_write` fails with big-endian
* [x] `fabio.test.codecs.test_fit2dmaskimage.TestMskWrite.testBzip2` fails with big-endian
* [x] `fabio.test.codecs.test_pixiimage.TestPixiImage.test_multi_frame` fails with big-endian
* [x] `fabio.test.test_agi_bitfield.TestUtil.test_compress_decode_field_overflow` fails with big-endian
* [x] `fabio.test.test_fabio_convert.TestFabioConvert.testSingleFile` fails with big-endian
* [x] `fabio.test.test_failing_files.TestFailingFiles.test_wrong_dm3` fails with big-endian