### PR TITLE
deprecation: setting an ndarray shape is deprecated since numpy 2.5.0

### DIFF
--- a/src/fabio/GEimage.py
+++ b/src/fabio/GEimage.py
@@ -343,7 +343,7 @@ class GeImage(FabioImage):
         data = numpy.frombuffer(raw, datatype).copy()
         if not numpy.little_endian:
             data.byteswap(True)
-        data.shape = rows, cols
+        data = data.reshape(rows, cols)
         self.data = data
         self._shape = None
         self.currentframe = int(img_num)

--- a/src/fabio/TiffIO.py
+++ b/src/fabio/TiffIO.py
@@ -408,7 +408,7 @@ class TiffIO(object):
                 tmpColormap = (tmpColormap / 256.0).astype(numpy.uint8)
             else:
                 tmpColormap = numpy.array(tmpColormap, dtype=numpy.uint8)
-            tmpColormap.shape = 3, -1
+            tmpColormap = tmpColormap.reshape(3, -1)
             colormap = numpy.zeros((tmpColormap.shape[-1], 3), tmpColormap.dtype)
             colormap[:, :] = tmpColormap.T
             tmpColormap = None
@@ -731,12 +731,12 @@ class TiffIO(object):
             if self._swap:
                 readout.byteswap(True)
             if hasattr(nBits, "index"):
-                readout.shape = -1, nColumns, len(nBits)
+                readout = readout.reshape(-1, nColumns, len(nBits))
             elif info["colormap"] is not None and interpretation == 3:
                 readout = colormap[readout]
-                readout.shape = -1, nColumns, 3
+                readout = readout.reshape(-1, nColumns, 3)
             else:
-                readout.shape = -1, nColumns
+                readout = readout.reshape(-1, nColumns)
             image[...] = readout
         else:
             for i in range(len(stripOffsets)):
@@ -786,12 +786,12 @@ class TiffIO(object):
                         readout.byteswap(True)
 
                     if hasattr(nBits, "index"):
-                        readout.shape = -1, nColumns, len(nBits)
+                        readout = readout.reshape(-1, nColumns, len(nBits))
                     elif info["colormap"] is not None:
                         readout = colormap[readout]
-                        readout.shape = -1, nColumns, 3
+                        readout = readout.reshape(-1, nColumns, 3)
                     else:
-                        readout.shape = -1, nColumns
+                        readout = readout.reshape(-1, nColumns)
                     image[rowStart:rowEnd, :] = readout
                 else:
                     readout = numpy.frombuffer(fd.read(nBytes), dtype).copy()
@@ -799,12 +799,12 @@ class TiffIO(object):
                         readout.byteswap(True)
 
                     if hasattr(nBits, "index"):
-                        readout.shape = -1, nColumns, len(nBits)
+                        readout = readout.reshape(-1, nColumns, len(nBits))
                     elif colormap is not None:
                         readout = colormap[readout]
-                        readout.shape = -1, nColumns, 3
+                        readout = readout.reshape(-1, nColumns, 3)
                     else:
-                        readout.shape = -1, nColumns
+                        readout = readout.reshape(-1, nColumns)
                     image[rowStart:rowEnd, :] = readout
                 rowStart += nRowsToRead
         if close:
@@ -845,7 +845,7 @@ class TiffIO(object):
         if len(image0.shape) == 1:
             # get a different view
             image = image0[:]
-            image.shape = 1, -1
+            image = image.reshape(1, -1)
         else:
             image = image0
 

--- a/src/fabio/app/hdf2neggia.py
+++ b/src/fabio/app/hdf2neggia.py
@@ -206,9 +206,8 @@ class XDSbuilder:
                     cnt += 1
                     if fimg.dataset.ndim < 3:
                         dataset = numpy.atleast_3d(fimg.dataset)
-                        dataset.shape = (1,) * (
-                            3 - fimg.dataset.ndim
-                        ) + fimg.dataset.shape
+                        new_shape = (1,) * (3 - fimg.dataset.ndim) + fimg.dataset.shape
+                        dataset = dataset.reshape(new_shape)
                     else:
                         dataset = fimg.dataset
                     data.create_dataset(
@@ -241,7 +240,8 @@ class XDSbuilder:
                             cnt += 1
                             if fimg.dataset.ndim < 3:
                                 dataset = numpy.atleast_3d(item)
-                                dataset.shape = (1,) * (3 - item.ndim) + item.shape
+                                new_shape = (1,) * (3 - item.ndim) + item.shape
+                                dataset = dataset.reshape(new_shape)
                             else:
                                 dataset = item
                             data.create_dataset(

--- a/src/fabio/cbfimage.py
+++ b/src/fabio/cbfimage.py
@@ -281,7 +281,7 @@ class CbfImage(FabioImage):
                 ),
                 self._dtype,
             )
-            data.shape = self._shape
+            data = data.reshape(self._shape)
             self.data = data
             self._shape = None
             self._dtype = None

--- a/src/fabio/dtrekimage.py
+++ b/src/fabio/dtrekimage.py
@@ -146,7 +146,7 @@ class DtrekImage(FabioImage):
                     # Older numpy without inplace
                     data = data.byteswap()
             try:
-                data.shape = self._shape
+                data = data.reshape(self._shape)
             except ValueError:
                 raise IOError(
                     "Size spec in d*TREK header does not match "

--- a/src/fabio/edfimage.py
+++ b/src/fabio/edfimage.py
@@ -897,7 +897,7 @@ class EdfImage(fabioimage.FabioImage):
                 )
                 # make sure we do not change the shape of the input data
                 stored_data = numpy.array(data, copy=False)
-                stored_data.shape = (1, len(data))
+                stored_data = stored_data.reshape(1, len(data))
             elif dim == 2:
                 stored_data = data
             elif dim >= 3:
@@ -1467,7 +1467,7 @@ class EdfImage(fabioimage.FabioImage):
             raw = f.read(frame.blobsize)
         try:
             data = numpy.frombuffer(raw, dtype=self.bytecode).copy()
-            data.shape = self.data.shape
+            data = data.reshape(self.data.shape)
         except Exception as error:
             logger.error("unable to convert file content to numpy array: %s", error)
         if frame.swap_needed():
@@ -1528,7 +1528,7 @@ class EdfImage(fabioimage.FabioImage):
             raw += b"\x00" * (size - len(raw))
         try:
             data = numpy.frombuffer(raw, dtype=self.bytecode).copy()
-            data.shape = -1, d1
+            data = data.reshape(-1, d1)
         except Exception as error:
             logger.error("unable to convert file content to numpy array: %s", error)
         if frame.swap_needed():

--- a/src/fabio/eigerimage.py
+++ b/src/fabio/eigerimage.py
@@ -197,7 +197,7 @@ class EigerImage(FabioImage):
                 else:
                     data = numpy.atleast_2d(ds)
                 if len(data.shape) == 2:
-                    data.shape = (1,) + data.shape
+                    data = data.reshape((1,) + data.shape)
                 chunks = (1,) + data.shape[-2:]
                 if len(self.dataset) > 1:
                     hds = data_grp.create_dataset(

--- a/src/fabio/fabioimage.py
+++ b/src/fabio/fabioimage.py
@@ -558,7 +558,7 @@ class FabioImage(_FabioArray):
     @shape.setter
     def shape(self, value):
         if self.data is not None:
-            self.data.shape = value
+            self.data = self.data.reshape(value)
         else:
             self._shape = value
 
@@ -714,7 +714,7 @@ class FabioImage(_FabioArray):
                         out += dataIn[i::y_rebin_fact, j::x_rebin_fact]
             else:  # method faster for large binning (8x8)
                 temp = self.data.astype("float64")
-                temp.shape = (shapeOut[0], y_rebin_fact, shapeOut[1], x_rebin_fact)
+                temp = temp.reshape(shapeOut[0], y_rebin_fact, shapeOut[1], x_rebin_fact)
                 out = temp.sum(axis=3).sum(axis=1)
         self.resetvals()
         if keep_I:

--- a/src/fabio/kcdimage.py
+++ b/src/fabio/kcdimage.py
@@ -171,7 +171,7 @@ class KcdImage(FabioImage):
             start = stop
             stop = (i + 1) * expected_size // nbReadOut
             data = numpy.frombuffer(block[start:stop], self._dtype).copy()
-            data.shape = dim2, dim1
+            data = data.reshape(dim2, dim1)
             if not numpy.little_endian:
                 data.byteswap(True)
             self.data += data

--- a/src/fabio/mrcimage.py
+++ b/src/fabio/mrcimage.py
@@ -179,7 +179,7 @@ class MrcImage(FabioImage):
         infile.seek(self._calc_offset(img_num), 0)
         data_buffer = infile.read(self.imagesize)
         data = numpy.frombuffer(data_buffer, self._dtype).copy()
-        data.shape = self._shape
+        data = data.reshape(self._shape)
         self.data = data
         self._shape = None
         self._dtype = None

--- a/src/fabio/pixiimage.py
+++ b/src/fabio/pixiimage.py
@@ -122,7 +122,7 @@ class PixiImage(fabioimage.FabioImage):
         data = numpy.frombuffer(
             filepointer.read(self._IMAGE_SIZE), numpy.dtype("<u2")
         ).copy()
-        data.shape = self.header["height"], self.header["width"]
+        data = data.reshape(self.header["height"], self.header["width"])
         return data
 
     def _readframe(self, filepointer, img_num):

--- a/src/fabio/pnmimage.py
+++ b/src/fabio/pnmimage.py
@@ -205,7 +205,7 @@ class PnmImage(FabioImage):
             raise IOError(
                 "Size spec in pnm-header does not match size of image data field"
             )
-        data.shape = self.shape
+        data = data.reshape(self.shape)
         if numpy.little_endian:
             data.byteswap(True)
         return data

--- a/src/fabio/test/codecs/test_mar345image.py
+++ b/src/fabio/test/codecs/test_mar345image.py
@@ -185,7 +185,7 @@ class TestMar345(unittest.TestCase):
         a = mar345_IO.calc_nb_bits(numpy.arange(50).astype("int32"), 0, 50)
         self.assertEqual(a, 350, 50 * 7)
 
-        img.shape = shape
+        img = img.reshape(shape)
         cmp_ccp4 = mar345_IO.compress_pck(img, use_CCP4=True)
         cmp_fab = mar345_IO.compress_pck(img, use_CCP4=False)
         delta = abs(len(cmp_fab) - len(cmp_ccp4))

--- a/src/fabio/test/test_tiffio.py
+++ b/src/fabio/test/test_tiffio.py
@@ -46,7 +46,7 @@ class TestTiffIO(unittest.TestCase):
         tif = TiffIO(filename, mode="wb+")
         dtype = numpy.uint16
         data = numpy.arange(10000).astype(dtype)
-        data.shape = 100, 100
+        data = data.reshape(100, 100)
         tif.writeImage(data, info={"Title": "1st"})
         tif = None
 
@@ -63,7 +63,7 @@ class TestTiffIO(unittest.TestCase):
         tif = TiffIO(filename, mode="rb+")
         dtype = numpy.uint16
         data = numpy.arange(100).astype(dtype)
-        data.shape = 10, 10
+        data = data.reshape(10, 10)
         tif.writeImage((data * 2).astype(dtype), info={"Title": "2nd"})
         self.assertEqual(tif.getNumberOfImages(), 2)
         tif = None

--- a/src/fabio/xsdimage.py
+++ b/src/fabio/xsdimage.py
@@ -115,7 +115,7 @@ class XsdImage(FabioImage):
             assert hashlib.md5(decData).hexdigest() == self.md5
 
         data = numpy.frombuffer(decData, dtype=self._dtype)
-        data.shape = self.shape
+        data = data.reshape(self.shape)
         self.data = data
 
         if not numpy.little_endian:  # by default little endian


### PR DESCRIPTION
For reference: https://github.com/silx-kit/silx/issues/4602#issuecomment-4637994839

Needed for the next silx release with https://github.com/silx-kit/silx/pull/4604.