### PR TITLE
fix: correct attribute name in register function (closes #659)

### DIFF
--- a/src/fabio/fabioformats.py
+++ b/src/fabio/fabioformats.py
@@ -116,7 +116,7 @@ def register(codec_class):
         raise AssertionError(
             "Expected subclass of FabioImage class but found %s" % type(codec_class)
         )
-    _registry[codec_class.codec_name()] = codec_class
+    _registry[codec_class.codec_name] = codec_class
     # clean u[p the cache
     _extension_cache = None
 


### PR DESCRIPTION
## What
In the `register` function of `fabioformats.py`, `codec_class.codec_name()` is called as a method, but `codec_name` is a property (attribute) in the `FabioImage` class, not a method. This causes an `AttributeError` or `TypeError` when registering codecs, breaking format discovery.

## Fix
Changed `codec_class.codec_name()` to `codec_class.codec_name` to access the attribute correctly.

Closes #659