### PR TITLE
fix: correct total size in AGI bitfield compression header (closes #659)

### DIFF
--- a/src/fabio/compression/agi_bitfield.py
+++ b/src/fabio/compression/agi_bitfield.py
@@ -85,10 +85,11 @@ def compress(frame):
         row_start[row_index] = buffer.tell()
         _compress_row(frame[row_index], buffer)
 
+    # Write row_start table before capturing final size
+    buffer.write(row_start.astype(LE_uint32).tobytes())
     data_size = pack("<I", buffer.tell())
 
-    buffer.write(row_start.astype(LE_uint32).tobytes())
-
+    # Now prepend the size header
     return data_size + buffer.getvalue()
 
 


### PR DESCRIPTION
## What
The compress function in `agi_bitfield.py` computed the data size header before writing the row_start table, causing the stored size to be smaller than the actual compressed data. This led to incorrect shape reconstruction when decompressing, resulting in errors like array shape mismatch (e.g., (1,2) vs (2,)) in tests like `test_get_data_edf`.

## Fix
Moved the writing of the row_start table before capturing the total buffer size. Now `data_size` includes the row_start table, ensuring the header accurately reflects the full compressed data length.

Closes #659